### PR TITLE
fix bing bert validation issue

### DIFF
--- a/bing_bert/deepspeed_train.py
+++ b/bing_bert/deepspeed_train.py
@@ -16,7 +16,7 @@ from turing.logger import Logger
 from turing.utils import get_sample_writer
 from turing.models import BertMultiTask
 from turing.dataset import PreTrainingDataset, PretrainBatch, PretrainDataType
-from turing.sources import PretrainingDataCreator
+from turing.sources import PretrainingDataCreator, WikiPretrainingDataCreator, TokenInstance
 from pytorch_pretrained_bert.tokenization import BertTokenizer
 from pytorch_pretrained_bert.optimization import BertAdam, warmup_linear, warmup_linear_decay_exp, warmup_exp_decay_exp, warmup_exp_decay_poly
 from utils import get_argument_parser, is_time_to_exit


### PR DESCRIPTION
From a previous merged pull request (https://github.com/microsoft/DeepSpeedExamples/pull/27), the "from turing.sources import WikiPretrainingDataCreator, TokenInstance" was removed from deepspeed_train.py. However, it seems like that they are required because we use WikiPretrainingDataCreator when loading the bing bert validation data:
https://github.com/microsoft/DeepSpeedExamples/blob/9e2c34e31cec99f7d5785c6a1a3b0854c322f883/bing_bert/turing/dataset.py#L278

Without the imports, I got this error: "AttributeError: Can't get attribute 'WikiPretrainingDataCreator' on <module '__main__' from '/home/conglli/DeepSpeedExamples/bing_bert_curriculum/deepspeed_train.py'>"