### PR TITLE
add codeowners and remove deepspeed.pt refs

### DIFF
--- a/BingBertSquad/nvidia_run_squad_baseline.py
+++ b/BingBertSquad/nvidia_run_squad_baseline.py
@@ -30,7 +30,6 @@ import pickle
 from tqdm import tqdm, trange
 from utils import get_argument_parser, \
     get_summary_writer, write_summary_events, \
-    dump_gradient_norms, dump_weight_norms, \
     is_time_to_exit, check_early_exit_warning
 
 import numpy as np

--- a/BingBertSquad/nvidia_run_squad_deepspeed.py
+++ b/BingBertSquad/nvidia_run_squad_deepspeed.py
@@ -30,7 +30,6 @@ import pickle
 from tqdm import tqdm, trange
 from utils import get_argument_parser, \
     get_summary_writer, write_summary_events, \
-    dump_gradient_norms, dump_weight_norms, \
     is_time_to_exit, check_early_exit_warning
 import deepspeed
 

--- a/BingBertSquad/utils.py
+++ b/BingBertSquad/utils.py
@@ -3,7 +3,6 @@ import sys
 import logging
 import argparse
 from tensorboardX import SummaryWriter
-from deepspeed.pt.deepspeed_utils import get_grad_norm, get_weight_norm
 
 SUMMARY_WRITER_DIR_NAME = 'runs'
 
@@ -227,24 +226,6 @@ def get_summary_writer(name, base=".."):
 def write_summary_events(summary_writer, summary_events):
     for event in summary_events:
         summary_writer.add_scalar(event[0], event[1], event[2])
-
-
-def dump_gradient_norms(tag, param_groups, micro_step, global_step):
-    norm_groups = []
-    for i, group in enumerate(param_groups):
-        norm_groups.append(get_grad_norm(group))
-    print(
-        "\n {} gradient_norms: micro_step={}, global_step={}, norms={}".format(
-            tag, micro_step, global_step, norm_groups))
-
-
-def dump_weight_norms(tag, param_groups, micro_step, global_step):
-    norm_groups = []
-    for i, group in enumerate(param_groups):
-        norm_groups.append(get_weight_norm(group))
-    print("\n {} weight_norms: micro_step={}, global_step={}, norms={}".format(
-        tag, micro_step, global_step, norm_groups))
-
 
 def is_time_to_exit(args, epoch_steps=0, global_steps=0):
     return (epoch_steps >= args.max_steps_per_epoch) or \

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @jeffra @samyam @tjruwase @ShadenSmith @conglongli @awan-10 @arashashari @cli99 @eltonzheng @minjiaz @RezaYazdaniAminabadi @niumanar

--- a/Megatron-LM/scripts/ds_checkpoint_check.sh
+++ b/Megatron-LM/scripts/ds_checkpoint_check.sh
@@ -44,7 +44,7 @@ gpt_options=" \
        --deepspeed_config ds_config_func_bs8.json
 "
 
-run_cmd="deepspeed.pt --num_nodes ${DLWS_NUM_WORKER} --num_gpus ${DLWS_NUM_GPU_PER_WORKER} pretrain_gpt2.py $@ ${gpt_options}"
+run_cmd="deepspeed --num_nodes ${DLWS_NUM_WORKER} --num_gpus ${DLWS_NUM_GPU_PER_WORKER} pretrain_gpt2.py $@ ${gpt_options}"
 echo ${run_cmd}
 eval ${run_cmd}
 

--- a/Megatron-LM/scripts/ds_zero2_pretrain_gpt2_model_parallel.sh
+++ b/Megatron-LM/scripts/ds_zero2_pretrain_gpt2_model_parallel.sh
@@ -41,7 +41,7 @@ gpt_options="${gpt_options}
 "
 
 
-run_cmd="deepspeed.pt --num_nodes ${NUM_WORKERS} --num_gpus ${NUM_GPUS_PER_WORKER} pretrain_gpt2.py $@ ${gpt_options}"
+run_cmd="deepspeed --num_nodes ${NUM_WORKERS} --num_gpus ${NUM_GPUS_PER_WORKER} pretrain_gpt2.py $@ ${gpt_options}"
 echo ${run_cmd}
 eval ${run_cmd}
 

--- a/bing_bert/deepspeed_train.py
+++ b/bing_bert/deepspeed_train.py
@@ -391,8 +391,7 @@ def prepare_model_optimizer(args):
     args.device = model.network.device
     model.set_device(args.device)
     args.fp16 = model.network.fp16_enabled()
-    args.use_lamb = model.network.optimizer_name(
-    ) == deepspeed.pt.deepspeed_config.LAMB_OPTIMIZER
+    args.use_lamb = model.network.optimizer_name() == deepspeed.LAMB_OPTIMIZER
 
     # Prepare Summary Writer and saved_models path
     if dist.get_rank() == 0:


### PR DESCRIPTION
The deepspeed refactor that is coming is having issues since for some reason our currently squad code is calling into deepspeed.pt which won't be the correct path. Also this code is not actually used in our squad example so removing it to clean up the code.