### PR TITLE
Fixed the dropout setting bug in DeepSpeed SQuDA fine-tune code

### DIFF
--- a/BingBertSquad/nvidia_run_squad_deepspeed.py
+++ b/BingBertSquad/nvidia_run_squad_deepspeed.py
@@ -828,8 +828,6 @@ def main():
         "hidden_act": "gelu",
         "hidden_dropout_prob": args.dropout,
         "attention_probs_dropout_prob": args.dropout,
-        "hidden_dropout_prob": 0.1,
-        "attention_probs_dropout_prob": 0.1,
         "max_position_embeddings": 512,
         "type_vocab_size": 2,
         "initializer_range": 0.02


### PR DESCRIPTION
It seems there is a bug in our DeepSpeed SQuDA finetune code. There are duplicated keys on dropout probability settings in the model configuration file. With the bug, it is possible that the second key-value pair overwrite the first one given the same key value, making setting dropout not really do anything in the current script. 