### PR TITLE
Add local rank explicitly for mpirun

### DIFF
--- a/BingBertSquad/nvidia_run_squad_deepspeed.py
+++ b/BingBertSquad/nvidia_run_squad_deepspeed.py
@@ -742,6 +742,7 @@ def main():
     parser = get_argument_parser()
 
     deepspeed.init_distributed(dist_backend='nccl')
+    args.local_rank = int(os.environ['LOCAL_RANK'])
 
     # Include DeepSpeed configuration arguments
     parser = deepspeed.add_config_arguments(parser)

--- a/bing_bert/deepspeed_train.py
+++ b/bing_bert/deepspeed_train.py
@@ -391,6 +391,7 @@ def prepare_optimizer_parameters(args, model):
 def prepare_model_optimizer(args):
     # Initialize torch distributed
     deepspeed.init_distributed(dist_backend='nccl')
+    args.local_rank = int(os.environ['LOCAL_RANK'])
 
     # Loading Model
     model = BertMultiTask(args)

--- a/pipeline_parallelism/train.py
+++ b/pipeline_parallelism/train.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import argparse
 
 import torch
@@ -148,8 +149,9 @@ def train_pipe(args, part='parameters'):
 if __name__ == '__main__':
     args = get_args()
 
-    torch.cuda.set_device(args.local_rank)
     deepspeed.init_distributed(dist_backend=args.backend)
+    args.local_rank = int(os.environ['LOCAL_RANK'])
+    torch.cuda.set_device(args.local_rank)
 
     if args.pipeline_parallel_size == 0:
         train_base(args)


### PR DESCRIPTION
Fix https://github.com/microsoft/DeepSpeed/issues/461. When the deepspeed launcher is used, the local rank is passed as an argument https://github.com/microsoft/DeepSpeed/blob/81aeea361da3936b875a678b9cb44596800510b5/deepspeed/launcher/launch.py#L123. But when we use the mpirun, it is not explicitly set and the deepspeed transformer cuda kernel requires this knowledge https://github.com/microsoft/DeepSpeedExamples/blob/78d69cb2f89a27b1e9b072df8c3e47d00c024fdc/bing_bert/nvidia/modelingpreln.py#L584.