### PR TITLE
additional no-decay keys for deepspeed transformer kernel

### DIFF
--- a/BingBertSquad/nvidia_run_squad_deepspeed.py
+++ b/BingBertSquad/nvidia_run_squad_deepspeed.py
@@ -849,6 +849,9 @@ def main():
     param_optimizer = [n for n in param_optimizer if 'pooler' not in n[0]]
 
     no_decay = ['bias', 'LayerNorm.bias', 'LayerNorm.weight']
+    if args.deepspeed_transformer_kernel:
+        no_decay = no_decay + ['attn_nw', 'attn_nb', 'norm_w', 'norm_b',
+                               'attn_qkvb', 'attn_ob', 'inter_b', 'output_b']
     optimizer_grouped_parameters = [{
         'params':
         [p for n, p in param_optimizer if not any(nd in n for nd in no_decay)],

--- a/bing_bert/deepspeed_train.py
+++ b/bing_bert/deepspeed_train.py
@@ -368,6 +368,9 @@ def prepare_optimizer_parameters(args, model):
     param_optimizer = list(model.network.named_parameters())
     param_optimizer = [n for n in param_optimizer if 'pooler' not in n[0]]
     no_decay = ['bias', 'LayerNorm.bias', 'LayerNorm.weight']
+    if args.deepspeed_transformer_kernel:
+        no_decay = no_decay + ['attn_nw', 'attn_nb', 'norm_w', 'norm_b',
+                               'attn_qkvb', 'attn_ob', 'inter_b', 'output_b']
     if "weight_decay" in config["training"].keys():
         weight_decay = config["training"]["weight_decay"]
     else:

--- a/bing_bert/run_glue_classifier_bert_base.py
+++ b/bing_bert/run_glue_classifier_bert_base.py
@@ -862,6 +862,9 @@ def main():
     # Prepare optimizer
     param_optimizer = list(model.named_parameters())
     no_decay = ['bias', 'LayerNorm.bias', 'LayerNorm.weight']
+    if args.deepspeed_transformer_kernel:
+        no_decay = no_decay + ['attn_nw', 'attn_nb', 'norm_w', 'norm_b',
+                               'attn_qkvb', 'attn_ob', 'inter_b', 'output_b']
     optimizer_grouped_parameters = [
         {'params': [p for n, p in param_optimizer if not any(
             nd in n for nd in no_decay)], 'weight_decay': 0.01},


### PR DESCRIPTION
Hi,

I found out that when using deepspeed transformer kernel, names of weights & bias inside the transformer kernels will end with 'attn_nw', 'norm_b' ... instead of 'bias', 'LayerNorm.weight' and 'LayerNorm.bias'.

This is a bug fix to exclude bias of GEMM and weights, bias of LayerNorm from the weight-decay dict.

Dong Xu