### PR TITLE
Fix int->string crash when saving model checkpoint

### DIFF
--- a/Megatron-LM/utils.py
+++ b/Megatron-LM/utils.py
@@ -238,7 +238,7 @@ def save_ds_checkpoint(iteration, model, args):
         sd['cuda_rng_state'] = torch.cuda.get_rng_state()
         sd['rng_tracker_states'] = mpu.get_cuda_rng_tracker().get_states()
         
-    model.save_checkpoint(args.save, iteration, client_state = sd)
+    model.save_checkpoint(args.save, None, client_state = sd)
 
 
 def get_checkpoint_iteration(args):


### PR DESCRIPTION
The `iteration` argument eventually gets passed to join(), which expects a string. This fix changes the argument to None, which lets the name get generated correctly as something like `global_step1000`.