### PR TITLE
remove duplicate config opt

### DIFF
--- a/Megatron-LM-v1.1.5-3D_parallelism/examples/ds_pretrain_gpt2_pipe.sh
+++ b/Megatron-LM-v1.1.5-3D_parallelism/examples/ds_pretrain_gpt2_pipe.sh
@@ -75,7 +75,6 @@ gpt_options=" \
         --weight-decay 1e-2 \
         --clip-grad 1.0 \
         --warmup 0.01 \
-        --checkpoint-activations \
         --log-interval 1 \
         --save-interval 500 \
         --eval-interval 100 \


### PR DESCRIPTION
`--checkpoint-activations` was being set twice.

this the other place:

https://github.com/microsoft/DeepSpeedExamples/blob/ce00e423b9ed4cc3ce20dab98861f6173094a557/Megatron-LM-v1.1.5-3D_parallelism/examples/ds_pretrain_gpt2_pipe.sh#L105