### PR TITLE
Apply dynamic loss scaling to example ds_config.json files

### DIFF
--- a/Megatron-LM-v1.1.5-ZeRO3/examples/ds_zero_stage_3_config_release.json
+++ b/Megatron-LM-v1.1.5-ZeRO3/examples/ds_zero_stage_3_config_release.json
@@ -19,7 +19,7 @@
   "gradient_clipping": 1.0,
   "fp16": {
     "enabled": true,
-    "loss_scale": 1024,
+    "loss_scale": 0,
     "loss_scale_window": 1000,
     "hysteresis": 2,
     "min_loss_scale": 1

--- a/Megatron-LM-v1.1.5-ZeRO3/examples/ds_zero_stage_infinity_config.json
+++ b/Megatron-LM-v1.1.5-ZeRO3/examples/ds_zero_stage_infinity_config.json
@@ -30,7 +30,7 @@
   "gradient_clipping": 1.0,
   "fp16": {
     "enabled": true,
-    "loss_scale": 1024,
+    "loss_scale": 0,
     "loss_scale_window": 1000,
     "hysteresis": 2,
     "min_loss_scale": 1

--- a/Megatron-LM/scripts/ds_zero-offload_10B_config.json
+++ b/Megatron-LM/scripts/ds_zero-offload_10B_config.json
@@ -18,7 +18,7 @@
   "gradient_clipping": 1.0,
   "fp16": {
     "enabled": true,
-    "loss_scale": 4096,
+    "loss_scale": 0,
     "loss_scale_window": 1000,
     "hysteresis": 2,
     "min_loss_scale": 1


### PR DESCRIPTION
Usually it's preferable to set the loss scaling as dynamic at the beginning when the training hyperparameters are less tuned. Thus after discussing with @tjruwase we agree to change all example ds_config files in Megatron example to use dynamic loss scaling.