### PR TITLE
fix typos on zero_stage_3_config json files

### DIFF
--- a/megatron/Megatron-LM-v1.1.5-ZeRO3/examples/ds_zero_stage_3_config.json
+++ b/megatron/Megatron-LM-v1.1.5-ZeRO3/examples/ds_zero_stage_3_config.json
@@ -7,7 +7,7 @@
     "stage3_max_live_parameters": 1e9,
     "stage3_max_reuse_distance": 1e9,
     "stage3_prefetch_bucket_size": 1e7,
-    "stage3_param_persitence_threshold": 1e5,
+    "stage3_param_persistence_threshold": 1e5,
     "reduce_bucket_size": 1e7,
     "contiguous_gradients": true
   },

--- a/megatron/Megatron-LM-v1.1.5-ZeRO3/examples/ds_zero_stage_3_config_release.json
+++ b/megatron/Megatron-LM-v1.1.5-ZeRO3/examples/ds_zero_stage_3_config_release.json
@@ -6,7 +6,7 @@
     "stage": 3,
     "stage3_max_live_parameters": 1e9,
     "stage3_max_reuse_distance": 1e8,
-    "stage3_param_persitance_threshold": 1e5,
+    "stage3_param_persistence_threshold": 1e5,
     "stage3_prefetch_bucket_size": 5e7,
     "contiguous_gradients": true,
     "cpu_offload": true,


### PR DESCRIPTION
`persistence` was written as `persitence`. 