### PR TITLE
Fix warning in GPT-Neo example and enable use_cache

### DIFF
--- a/inference/huggingface/text-generation/test-gpt-neo.py
+++ b/inference/huggingface/text-generation/test-gpt-neo.py
@@ -23,5 +23,5 @@ generator.model = deepspeed.init_inference(generator.model,
                                            dtype=torch.float,
                                            replace_method='auto',
                                            replace_with_kernel_inject=True)
-string = generator("DeepSpeed is", do_sample=True, min_length=50)
+string = generator("DeepSpeed is", min_length=50, max_length=50, do_sample=True, use_cache=True)
 print(string)


### PR DESCRIPTION
This PR fixes the following warning in the `test-gpt-neo.py` text-generation example by explicitly specifying the `max_length` argument:
```
UserWarning: Neither `max_length` nor `max_new_tokens` have been set, `max_length` will default to 50 (`self.config.max_length`). Controlling `max_length` via the config is deprecated and `max_length` will be removed from the config in v5 of Transformers -- we recommend using `max_new_tokens` to control the maximum length of the generation. 
```
It also sets `use_cache=True` when calling the generator to stay consistent with other text-generation examples.
