### PR TITLE
New inference tests for bart, blenderbot, codegen, and mvp

### DIFF
--- a/inference/huggingface/text-generation/test-codegen.py
+++ b/inference/huggingface/text-generation/test-codegen.py
@@ -1,0 +1,29 @@
+from transformers import pipeline
+import transformers
+import deepspeed
+import torch
+import os
+from transformers.models.codegen.modeling_codegen import CodeGenBlock
+
+local_rank = int(os.getenv('LOCAL_RANK', '0'))
+world_size = int(os.getenv('WORLD_SIZE', '1'))
+
+pipe = pipeline("text-generation", model="Salesforce/codegen-350M-mono", device=local_rank)
+
+# The injection_policy shows two things:
+#   1. which layer module we need to add Tensor-Parallelism
+#   2. the name of several linear layers: a) attention_output (both encoder and decoder),
+#       and b) transformer output
+
+pipe.model = deepspeed.init_inference(
+    pipe.model,
+    mp_size=world_size,
+    dtype=torch.float,
+    injection_policy={CodeGenBlock: ('mlp.fc_out', 'attn.out_proj')}
+)
+
+pipe.device = torch.device(f'cuda:{local_rank}')
+output = pipe("def hello_world():")
+
+if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+    print(output)

--- a/inference/huggingface/text2text-generation/test-bart.py
+++ b/inference/huggingface/text2text-generation/test-bart.py
@@ -22,7 +22,7 @@ pipe.model = deepspeed.init_inference(
     injection_policy={
         BartEncoderLayer: ('.fc2', 'self_attn.out_proj'),
         BartDecoderLayer: ('encoder_attn.out_proj', '.fc2', 'self_attn.out_proj')
-        }
+    }
 )
 
 pipe.device = torch.device(f'cuda:{local_rank}')

--- a/inference/huggingface/text2text-generation/test-bart.py
+++ b/inference/huggingface/text2text-generation/test-bart.py
@@ -1,0 +1,32 @@
+from transformers import pipeline
+import transformers
+import deepspeed
+import torch
+import os
+from transformers.models.bart.modeling_bart import BartEncoderLayer, BartDecoderLayer
+
+local_rank = int(os.getenv('LOCAL_RANK', '0'))
+world_size = int(os.getenv('WORLD_SIZE', '1'))
+
+pipe = pipeline("text2text-generation", model="facebook/bart-large", device=local_rank)
+
+# The injection_policy shows two things:
+#   1. which layer module we need to add Tensor-Parallelism
+#   2. the name of several linear layers: a) attention_output (both encoder and decoder),
+#       and b) transformer output
+
+pipe.model = deepspeed.init_inference(
+    pipe.model,
+    mp_size=world_size,
+    dtype=torch.float,
+    injection_policy={
+        BartEncoderLayer: ('.fc2', 'self_attn.out_proj'),
+        BartDecoderLayer: ('encoder_attn.out_proj', '.fc2', 'self_attn.out_proj')
+        }
+)
+
+pipe.device = torch.device(f'cuda:{local_rank}')
+output = pipe("UN Chief Says There Is No <mask> in Syria")
+
+if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+    print(output)

--- a/inference/huggingface/text2text-generation/test-blenderbot.py
+++ b/inference/huggingface/text2text-generation/test-blenderbot.py
@@ -21,7 +21,8 @@ pipe.model = deepspeed.init_inference(
     dtype=torch.float,
     injection_policy={
         BlenderbotEncoderLayer: ('.fc2', 'self_attn.out_proj'),
-        BlenderbotDecoderLayer: ('.fc2', 'encoder_attn.out_proj', 'self_attn.out_proj')}
+        BlenderbotDecoderLayer: ('.fc2', 'encoder_attn.out_proj', 'self_attn.out_proj')
+    }
 )
 
 pipe.device = torch.device(f'cuda:{local_rank}')

--- a/inference/huggingface/text2text-generation/test-mvp.py
+++ b/inference/huggingface/text2text-generation/test-mvp.py
@@ -19,7 +19,10 @@ pipe.model = deepspeed.init_inference(
     pipe.model,
     mp_size=world_size,
     dtype=torch.float,
-    injection_policy={MvpDecoderLayer: ('self_attn.out_proj', 'encoder_attn.out_proj', '.fc2'), MvpEncoderLayer: ('self_attn.out_proj', '.fc2')}
+    injection_policy={
+        MvpDecoderLayer: ('self_attn.out_proj', 'encoder_attn.out_proj', '.fc2'), 
+        MvpEncoderLayer: ('self_attn.out_proj', '.fc2')
+    }
 )
 
 pipe.device = torch.device(f'cuda:{local_rank}')


### PR DESCRIPTION
Replicated same examples from transformers documentation using new auto-generated injection policies. Tested for 1 and 2 gpus.