### PR TITLE
Add device comprehension to BLOOM Pipeline utility class

### DIFF
--- a/inference/huggingface/text-generation/test-bloom.py
+++ b/inference/huggingface/text-generation/test-bloom.py
@@ -15,7 +15,9 @@ local_rank = int(os.getenv('LOCAL_RANK', '0'))
 world_size = int(os.getenv('WORLD_SIZE', '1'))
 
 pipe = Pipeline(model_name=model_name,
-                dtype=dtype
+                dtype=dtype,
+                is_meta=True,
+                device=local_rank
 )
 
 pipe.model = deepspeed.init_inference(


### PR DESCRIPTION
This PR adds device comprehension to the BLOOM `Pipeline` utility class to expand support for devices and also support the case where the DeepSpeed `init_inference` API isn't used.