### PR TITLE
Update init_inference API max_out_tokens param after config refactor

### DIFF
--- a/inference/huggingface/text-generation/inference-test.py
+++ b/inference/huggingface/text-generation/inference-test.py
@@ -39,7 +39,7 @@ if args.ds_inference:
                                     dtype=data_type,
                                     mp_size=world_size,
                                     replace_with_kernel_inject=True,
-                                    max_tokens=args.max_tokens,
+                                    max_out_tokens=args.max_tokens,
                                     **ds_kwargs
                                     )
 


### PR DESCRIPTION
After the DeepSpeed [config refactor](https://github.com/microsoft/DeepSpeed/pull/2472), the `init_inference` API call in the `inference-test.py` example needs to update its argument name from `max_tokens` to `max_out_tokens`.

Thanks to @molly-smith for identifying this issue.