### PR TITLE
Set replace_with_kernel_inject=True in BERT fill-mask example

### DIFF
--- a/inference/huggingface/fill-mask/test-bert.py
+++ b/inference/huggingface/fill-mask/test-bert.py
@@ -14,7 +14,7 @@ pipe.model = deepspeed.init_inference(
     pipe.model,
     mp_size=world_size,
     dtype=torch.float,
-    injection_policy={BertLayer : ('output.dense')}
+    replace_with_kernel_inject=True
 )
 
 pipe.device = torch.device(f'cuda:{local_rank}')


### PR DESCRIPTION
This PR sets `replace_with_kernel_inject=True` in the BERT fill-mask inference example.