### PR TITLE
Fix ds_inference_config.json string

### DIFF
--- a/inference/huggingface/text-generation/utils.py
+++ b/inference/huggingface/text-generation/utils.py
@@ -77,8 +77,8 @@ class DSPipeline():
                                       revision=None)
         else:
             repo_root = checkpoint_path
-        if os.path.exists(os.path.join(repo_root, "ds-inference_config.json")):
-            checkpoints_json = os.path.join(repo_root, "ds-inference_config.json")
+        if os.path.exists(os.path.join(repo_root, "ds_inference_config.json")):
+            checkpoints_json = os.path.join(repo_root, "ds_inference_config.json")
         elif (self.model_name in self.tp_presharded_models):
             # tp presharded repos come with their own checkpoints config file
             checkpoints_json = os.path.join(repo_root, "ds_inference_config.json")


### PR DESCRIPTION
This PR changes the string in the DSPipeline class from `ds-inference_config.json` to `ds_inference_config.json`, to match what's generated after the update in https://github.com/microsoft/DeepSpeed/pull/2561.

<pre>
-            with open(f"{config.save_mp_checkpoint_path}/ds-inference_config.json",
+            with open(f"{config.save_mp_checkpoint_path}/ds_inference_config.json",
</pre>

https://github.com/microsoft/DeepSpeed/pull/2561/files#diff-cf74152f0933aa49e65fc12cb0017a40f5b6e2880bd7c01e0d2b26693b6c88e7

@RezaYazdaniAminabadi 