### PR TITLE
Fix syntax and dependency error for cifar

### DIFF
--- a/cifar/cifar10_tutorial.py
+++ b/cifar/cifar10_tutorial.py
@@ -110,7 +110,7 @@ def imshow(img):
 
 # get some random training images
 dataiter = iter(trainloader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # show images
 imshow(torchvision.utils.make_grid(images))
@@ -219,7 +219,7 @@ torch.save(net.state_dict(), PATH)
 # Okay, first step. Let us display an image from the test set to get familiar.
 
 dataiter = iter(testloader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # print images
 imshow(torchvision.utils.make_grid(images))

--- a/cifar/requirements.txt
+++ b/cifar/requirements.txt
@@ -1,3 +1,3 @@
-torchvision==0.4.0
+torchvision
 pillow>=7.1.0
 matplotlib


### PR DESCRIPTION
1. `pip install torchvision==0.4` results in the error: 
  ```
  ERROR: Could not find a version that satisfies the requirement torchvision==0.4 (from versions: 0.1.6, 0.1.7, 0.1.8, 0.1.9, 0.2.0, 0.2.1, 0.2.2, 0.2.2.post2, 0.2.2.post3, 0.8.2, 0.9.0, 0.9.1, 0.10.0, 0.10.1, 0.11.0, 0.11.1, 0.11.2, 0.11.3, 0.12.0, 0.13.0, 0.13.1, 0.14.0, 0.14.1)
  ERROR: No matching distribution found for torchvision==0.4
  ```
2. From PyTorch 1.13 one should use `next(iter(loader))` instead of `iter(loader).next()`.