### PR TITLE
Add triton==2.0.0.dev20221202 to SD requirements

### DIFF
--- a/inference/huggingface/stable-diffusion/requirements.txt
+++ b/inference/huggingface/stable-diffusion/requirements.txt
@@ -1,3 +1,4 @@
 deepspeed
 torch
 diffusers
+triton==2.0.0.dev20221202


### PR DESCRIPTION
This PR adds `triton==2.0.0.dev20221202` to the Stable Diffusion example `requirements.txt` since that's a version that's tested and available.

Related to https://github.com/microsoft/DeepSpeed/pull/3135.