### PR TITLE
Relax DeepSpeed-Chat requirements

### DIFF
--- a/applications/DeepSpeed-Chat/requirements.txt
+++ b/applications/DeepSpeed-Chat/requirements.txt
@@ -1,5 +1,5 @@
 datasets>=2.8.0
-sentencepiece=>=0.1.97
+sentencepiece>=0.1.97
 protobuf==3.20.3
 accelerate>=0.15.0
 torch>=1.12.0

--- a/applications/DeepSpeed-Chat/requirements.txt
+++ b/applications/DeepSpeed-Chat/requirements.txt
@@ -1,7 +1,7 @@
-datasets==2.11.0
-sentencepiece==0.1.97
-protobuf==4.22.1
-accelerate==0.18.0
-torch==1.12.1
+datasets>=2.8.0
+sentencepiece=>=0.1.97
+protobuf==3.20.3
+accelerate>=0.15.0
+torch>=1.12.0
 git+https://github.com/microsoft/deepspeed.git
 git+https://github.com/huggingface/transformers


### PR DESCRIPTION
Extending #273 to relax all our requirements.

- Tested with `torch<1.12.0` and found OOM where `torch>=1.12.0` did not OOM
- Fixed `protobuf==3.20.3` to avoid common warning/error regarding `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python`
- Rest of packages are required to be somewhat recent. Might work with older versions of these packages.

Co-authored-by: Yueming Hao <yhao24@ncsu.edu>