### PR TITLE
Update typo in README.md

### DIFF
--- a/applications/DeepSpeed-Chat/README.md
+++ b/applications/DeepSpeed-Chat/README.md
@@ -167,7 +167,7 @@ Want to try different model sizes and configurations? You got it! With DeepSpeed
   | Actor: OPT-66B  Reward: OPT-350M | 82mins | 5mins  | 7.5hr  | 9hr   |
  </p></details>
 
- For your detailed budgeting for training a wide spectrum of model sizes on potentially avlaiable computing resources (e.g., Microsoft Azure), please visit [Training Performance Evaluation](#-training-performance-evaluation-).
+ For your detailed budgeting for training a wide spectrum of model sizes on potentially available computing resources (e.g., Microsoft Azure), please visit [Training Performance Evaluation](#-training-performance-evaluation-).
 
 ### 🐼 Demonstration: Individual Step Fine-Tuning
 


### PR DESCRIPTION
Typo in readme, see commit / file changes. "available" corrected. Earlier commit accidentally closed.