### PR TITLE
Unit in (model-only) latency

### DIFF
--- a/benchmarks/inference/gpt-bench.py
+++ b/benchmarks/inference/gpt-bench.py
@@ -97,7 +97,7 @@ for i in range(args.trials):
     responses.append(r)
     times.append(end - start)  # / (args.max_tokens - 3))
     if args.deepspeed:
-        mtimes.append(sum(pipe.model.model_times()))
+        mtimes.append(sum(pipe.model.model_times()) / 1000)
 
 if args.local_rank == 0:
     print_latency(times, "(e2e) latency")


### PR DESCRIPTION
`mtimes` is multiple by 1000 to get the time in the unit of ms in `print_latency`, but it is already in the unit of ms.

`use_cuda_events` is true by default in function `profile_model_time`.

From https://pytorch.org/docs/stable/generated/torch.cuda.Event.html,

> Returns the time elapsed in milliseconds after the event was recorded and before the end_event was recorded.