### PR TITLE
Pass generation config to Hybrid Engine

### DIFF
--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/rlhf_engine.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/rlhf_engine.py
@@ -72,7 +72,9 @@ class DeepSpeedRLHFEngine():
             inference_tp_size=self.args.inference_tp_size,
             release_inference_cache=self.args.release_inference_cache,
             pin_parameters=(not self.args.unpin_actor_parameters),
-            tp_gather_partition_size=self.args.tp_gather_partition_size)
+            tp_gather_partition_size=self.args.tp_gather_partition_size,
+            max_out_tokens=self.args.max_prompt_seq_len +
+            self.args.max_answer_seq_len)
         ds_config[
             'train_micro_batch_size_per_gpu'] = self.args.per_device_mini_train_batch_size
         #TODO(jeff): we should probably set grad accumlation steps here as well for clarity

--- a/applications/DeepSpeed-Chat/training/utils/ds_utils.py
+++ b/applications/DeepSpeed-Chat/training/utils/ds_utils.py
@@ -12,7 +12,8 @@ def get_train_ds_config(offload,
                         inference_tp_size=1,
                         release_inference_cache=False,
                         pin_parameters=True,
-                        tp_gather_partition_size=8):
+                        tp_gather_partition_size=8,
+                        max_out_tokens=512):
 
     device = "cpu" if offload else "none"
     zero_opt_dict = {
@@ -42,6 +43,7 @@ def get_train_ds_config(offload,
         "wall_clock_breakdown": False,
         "hybrid_engine": {
             "enabled": enable_hybrid_engine,
+            "max_out_tokens": max_out_tokens,
             "inference_tp_size": inference_tp_size,
             "release_inference_cache": release_inference_cache,
             "pin_parameters": pin_parameters,


### PR DESCRIPTION
Propagates non-default prompt + answer length configurations to the Hybrid Engine for proper generation.