### PR TITLE
Fix padding on prompt batch

### DIFF
--- a/applications/DeepSpeed-Chat/training/utils/data/data_utils.py
+++ b/applications/DeepSpeed-Chat/training/utils/data/data_utils.py
@@ -367,11 +367,11 @@ class DataCollatorRLHF:
         pad_length = self.max_token_len - length
         if pad_length > 0:
             batch["prompt"] = F.pad(prompt,
-                                    pad=(pad_length, 0),
+                                    pad=(0, pad_length),
                                     mode='constant',
                                     value=pad_token_id)
             batch["prompt_att_mask"] = F.pad(prompt_mask,
-                                             pad=(pad_length, 0),
+                                             pad=(0, pad_length),
                                              mode='constant',
                                              value=0)
         else:


### PR DESCRIPTION
We have to do padding at right here because further it flips and becomes left-padded. So finally prompt batch becomes right-aligned and left-padded as usually required for GPT generation.