### PR TITLE
Provide attention mask of prompts to hf-generation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE files
+.idea

--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
@@ -422,12 +422,13 @@ def main():
                 unsup_dataset = unsup_mini_dataset.add(
                     [[None] * args.per_device_train_batch_size])
             prompts = batch_prompt['prompt']
+            prompt_att_mask = batch_prompt['prompt_att_mask']
             length = prompts.size(-1)
             if length > args.max_prompt_seq_len:
                 prompts = prompts[:, length - args.max_prompt_seq_len:]
                 raise ValueError("Prompt length is too long")
 
-            out = trainer.generate_experience(prompts)
+            out = trainer.generate_experience(prompts, prompt_att_mask)
             exp_dataset = exp_mini_dataset.add(out)
 
             if exp_dataset is not None:

--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/ppo_trainer.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/ppo_trainer.py
@@ -65,12 +65,13 @@ class DeepSpeedPPOTrainer():
         self.gamma = 1.0
         self.lam = 0.95
 
-    def _generate_sequence(self, prompts):
+    def _generate_sequence(self, prompts, attention_mask):
 
         max_min_length = self.max_answer_seq_len + prompts.shape[1]
 
         with torch.no_grad():
             seq = self.actor_model.module.generate(prompts,
+                                                   attention_mask=attention_mask,
                                                    max_length=max_min_length,
                                                    min_length=max_min_length)
 
@@ -92,9 +93,9 @@ class DeepSpeedPPOTrainer():
 
         return out_seq
 
-    def generate_experience(self, prompts):
+    def generate_experience(self, prompts, attention_mask):
         self.eval()
-        seq = self._generate_sequence(prompts)
+        seq = self._generate_sequence(prompts, attention_mask)
         self.train()
 
         pad_token_id = self.tokenizer.pad_token_id


### PR DESCRIPTION
In case if model has no padding token in its config (often case) and attention mask is not provided the hf generation script generates attention mask fulfilled by ones. Therefore many eos tokens in prompts which were used as paddings fall into attention of model and crash the generation. (note that DSChat do pad_token = eos_token only in tokenizer, not in model)
So as we have attention mask for prompts why not to provide it to hf generation script? Lets do so!

Additionally, added ignoring files of PyCharm IDE.