### PR TITLE
Fix to allow hf-generation to generate eos-token

### DIFF
--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/ppo_trainer.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/ppo_trainer.py
@@ -67,13 +67,12 @@ class DeepSpeedPPOTrainer():
 
     def _generate_sequence(self, prompts, mask):
 
-        max_min_length = self.max_answer_seq_len + prompts.shape[1]
+        max_length = self.max_answer_seq_len + prompts.shape[1]
 
         with torch.no_grad():
             seq = self.actor_model.module.generate(prompts,
                                                    attention_mask=mask,
-                                                   max_length=max_min_length,
-                                                   min_length=max_min_length)
+                                                   max_length=max_length)
 
         # Filter out seq with no answers (or very short). This happens when users directly use the pre-training ckpt without supervised finetuning
         # NOTE: this will causes each GPU has different number of examples


### PR DESCRIPTION
Providing min_length = max_length to hf generation script leads that it adds logit processor which suppress eos token appearing. So generation never stops until max_length is reached. Sequences generated in such a way then evaluated by reward model. So it produce a bias in marks against evaluation samples. 