### PR TITLE
Support huggyllama/llama-*b models with DSPipeline

### DIFF
--- a/inference/huggingface/text-generation/utils.py
+++ b/inference/huggingface/text-generation/utils.py
@@ -9,7 +9,7 @@ import json
 import deepspeed
 import torch
 from huggingface_hub import snapshot_download
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, LlamaTokenizerFast
 
 class DSPipeline():
     '''
@@ -108,9 +108,12 @@ class DSPipeline():
 
         self.model.cuda().to(self.device)
 
-        # NOTE: Check if Llamma can work w/ **input_tokens
-        #       'token_type_ids' kwarg not recognized in Llamma generate function
-        outputs = self.model.generate(input_tokens.input_ids, **generate_kwargs)
+        if isinstance(self.tokenizer, LlamaTokenizerFast):
+            # NOTE: Check if Llamma can work w/ **input_tokens
+            #       'token_type_ids' kwarg not recognized in Llamma generate function
+            outputs = self.model.generate(input_tokens.input_ids, **generate_kwargs)
+        else:
+            outputs = self.model.generate(**input_tokens, **generate_kwargs)
         outputs = self.tokenizer.batch_decode(outputs, skip_special_tokens=True)
 
         return outputs

--- a/inference/huggingface/text-generation/utils.py
+++ b/inference/huggingface/text-generation/utils.py
@@ -108,7 +108,9 @@ class DSPipeline():
 
         self.model.cuda().to(self.device)
 
-        outputs = self.model.generate(**input_tokens, **generate_kwargs)
+        # NOTE: Check if Llamma can work w/ **input_tokens
+        #       'token_type_ids' kwarg not recognized in Llamma generate function
+        outputs = self.model.generate(input_tokens.input_ids, **generate_kwargs)
         outputs = self.tokenizer.batch_decode(outputs, skip_special_tokens=True)
 
         return outputs


### PR DESCRIPTION
During token encoding for the `huggyllama/llama-7b` model, `self.tokenizer.batch_encode_plus` returns a `token_type_ids` kwarg that isn't recognized in the model's `generate` function.

This is due to `AutoTokenizer` returning `LlamaTokenizerFast` instead of `LlamaTokenizer` as seen in the model tokenizer config:
https://huggingface.co/huggyllama/llama-7b/blob/8416d3fefb0cb3ff5775a7b13c1692d10ff1aa16/tokenizer_config.json#L24

As a workaround, the `DSPipeline` will check to see if the tokenizer is `LlamaTokenizerFast` and only pass in `input_tokens.input_ids` to the `self.model.generate(...)` call if that is the case.