### PR TITLE
[DeepSpeed-Chat] feat: Support local path for actor, reward models.

### DIFF
--- a/applications/DeepSpeed-Chat/train.py
+++ b/applications/DeepSpeed-Chat/train.py
@@ -55,14 +55,14 @@ def parse_args():
     )
     parser.add_argument(
         "--actor-model",
-        type=lambda x: x.split("-")[-1],
+        type=lambda pth: [fn.split("-")[-1] for fn in pth.split("/") if "opt" in fn][-1],
         default="1.3b",
         choices=("350m", "1.3b", "6.7b", "13b", "66b"),
         help="Which facebook/opt-* model to use for Actor (step 1)",
     )
     parser.add_argument(
         "--reward-model",
-        type=lambda x: x.split("-")[-1],
+        type=lambda pth: [fn.split("-")[-1] for fn in pth.split("/") if "opt" in fn][-1],
         default="350m",
         choices=("350m"),
         help="Which facebook/opt-* model to use for Reward (step 2)",

--- a/applications/DeepSpeed-Chat/train.py
+++ b/applications/DeepSpeed-Chat/train.py
@@ -55,14 +55,14 @@ def parse_args():
     )
     parser.add_argument(
         "--actor-model",
-        type=lambda x: x.replace("facebook/opt-", ""),
+        type=lambda x: x.split("-")[-1],
         default="1.3b",
-        choices=("1.3b", "6.7b", "13b", "66b"),
+        choices=("350m", "1.3b", "6.7b", "13b", "66b"),
         help="Which facebook/opt-* model to use for Actor (step 1)",
     )
     parser.add_argument(
         "--reward-model",
-        type=lambda x: x.replace("facebook/opt-", ""),
+        type=lambda x: x.split("-")[-1],
         default="350m",
         choices=("350m"),
         help="Which facebook/opt-* model to use for Reward (step 2)",


### PR DESCRIPTION
This pull request updates the parameter `--actor-model` and `--reward-model` to use NAS path by multi nodes.

demo 1:

```bash
python train.py --actor-model facebook/opt-350m --reward-model facebook/opt-350m --deployment-type single_gpu --step 1
```

demo 2:
```bash
python train.py --actor-model /data/models/facebook/opt-350m --reward-model /data/models/facebook/opt-350m --deployment-type single_gpu --step 1

---=== Running Step 1 ===---
Running:
bash /code/yiminjiang/DeepSpeedExamples/applications/DeepSpeed-Chat/training/step1_supervised_finetuning/training_scripts/single_gpu/run_350m.sh /code/yiminjiang/DeepSpeedExamples/applications/DeepSpeed-Chat/output/actor-models/350m
```