### PR TITLE
Support bf16 in training scripts

### DIFF
--- a/applications/DeepSpeed-Chat/training/step1_supervised_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step1_supervised_finetuning/main.py
@@ -161,6 +161,9 @@ def parse_args():
     parser.add_argument('--only_optimize_lora',
                         action='store_true',
                         help='Only optimize the LoRA parameters.')
+    parser.add_argument('--bf16',
+                        action='store_true',
+                        help='Use bf16.')
     parser = deepspeed.add_config_arguments(parser)
     args = parser.parse_args()
 
@@ -188,7 +191,8 @@ def main():
     args.global_rank = torch.distributed.get_rank()
 
     ds_config = get_train_ds_config(offload=args.offload,
-                                    stage=args.zero_stage)
+                                    stage=args.zero_stage,
+                                    bf16=args.bf16)
     ds_config[
         'train_micro_batch_size_per_gpu'] = args.per_device_train_batch_size
     ds_config[

--- a/applications/DeepSpeed-Chat/training/step2_reward_model_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step2_reward_model_finetuning/main.py
@@ -161,6 +161,9 @@ def parse_args():
     parser.add_argument('--only_optimize_lora',
                         action='store_true',
                         help='Only optimize the LoRA parameters.')
+    parser.add_argument('--bf16',
+                        action='store_true',
+                        help='Use bf16.')
     parser = deepspeed.add_config_arguments(parser)
     args = parser.parse_args()
 
@@ -188,7 +191,8 @@ def main():
     args.global_rank = torch.distributed.get_rank()
 
     ds_config = get_train_ds_config(offload=args.offload,
-                                    stage=args.zero_stage)
+                                    stage=args.zero_stage,
+                                    bf16=args.bf16)
     ds_config[
         'train_micro_batch_size_per_gpu'] = args.per_device_train_batch_size
     ds_config[

--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
@@ -285,6 +285,9 @@ def parse_args():
     parser.add_argument('--enable_ema',
                         action='store_true',
                         help='Enable EMA checkpoint for the model.')
+    parser.add_argument('--bf16',
+                        action='store_true',
+                        help='Use bf16.')
 
     parser = deepspeed.add_config_arguments(parser)
     args = parser.parse_args()

--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/rlhf_engine.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/rlhf_engine.py
@@ -74,7 +74,8 @@ class DeepSpeedRLHFEngine():
             pin_parameters=(not self.args.unpin_actor_parameters),
             tp_gather_partition_size=self.args.tp_gather_partition_size,
             max_out_tokens=self.args.max_prompt_seq_len +
-            self.args.max_answer_seq_len)
+            self.args.max_answer_seq_len,
+            bf16=self.args.bf16)
         ds_config[
             'train_micro_batch_size_per_gpu'] = self.args.per_device_mini_train_batch_size
         #TODO(jeff): we should probably set grad accumlation steps here as well for clarity
@@ -133,7 +134,8 @@ class DeepSpeedRLHFEngine():
             # If actor is ZeRO-3 then we use it for everything, otherwise assume we have enough memory for ref model
             zero_stage = 0
         ds_config = get_eval_ds_config(self.args.offload_reference_model,
-                                       zero_stage)
+                                       zero_stage,
+                                       bf16=self.args.bf16)
         ds_config[
             'train_micro_batch_size_per_gpu'] = self.args.per_device_mini_train_batch_size
         #TODO(jeff): we should probably set grad accumlation steps here as well for clarity
@@ -159,7 +161,8 @@ class DeepSpeedRLHFEngine():
             # If actor is ZeRO-3 then we use it for everything, otherwise assume we have enough memory
             zero_stage = 0
         ds_config = get_eval_ds_config(self.args.offload_reference_model,
-                                       zero_stage)
+                                       zero_stage,
+                                       bf16=self.args.bf16)
         ds_config[
             'train_micro_batch_size_per_gpu'] = self.args.per_device_mini_train_batch_size
         #TODO(jeff): we should probably set grad accumlation steps here as well for clarity
@@ -184,7 +187,8 @@ class DeepSpeedRLHFEngine():
     def _init_critic(self, critic_model_name_or_path):
         stime = log_init("Critic")
         ds_config = get_train_ds_config(offload=self.args.offload,
-                                        stage=self.args.critic_zero_stage)
+                                        stage=self.args.critic_zero_stage,
+                                        bf16=self.args.bf16)
         ds_config[
             'train_micro_batch_size_per_gpu'] = self.args.per_device_mini_train_batch_size
         #TODO(jeff): we should probably set grad accumlation steps here as well for clarity
@@ -194,7 +198,7 @@ class DeepSpeedRLHFEngine():
 
         #TODO(jeff): should not be needed, we should be able to use ds_config above
         #TODO(jeff): it means we never create the critic w. zero.init context if we are using ZeRO-3
-        ds_eval_config = get_eval_ds_config(offload=False, stage=0)
+        ds_eval_config = get_eval_ds_config(offload=False, stage=0, bf16=self.args.bf16)
 
         # Model
         critic_model = create_critic_model(
@@ -247,7 +251,8 @@ class DeepSpeedRLHFEngine():
             zero_stage = 0
 
         ds_config = get_eval_ds_config(offload=self.args.offload,
-                                       stage=zero_stage)
+                                       stage=zero_stage,
+                                       bf16=self.args.bf16)
         ds_config[
             'train_micro_batch_size_per_gpu'] = self.args.per_device_mini_train_batch_size
         ds_config[
@@ -256,7 +261,7 @@ class DeepSpeedRLHFEngine():
 
         #TODO(jeff): should not be needed, we should be able to use ds_config above
         #TODO(jeff): it means we never create the critic w. zero.init context if we are using ZeRO-3
-        ds_eval_config = get_eval_ds_config(offload=False, stage=0)
+        ds_eval_config = get_eval_ds_config(offload=False, stage=0, bf16=self.args.bf16)
 
         # Model
         reward_model = create_critic_model(

--- a/applications/DeepSpeed-Chat/training/utils/ds_utils.py
+++ b/applications/DeepSpeed-Chat/training/utils/ds_utils.py
@@ -13,7 +13,8 @@ def get_train_ds_config(offload,
                         release_inference_cache=False,
                         pin_parameters=True,
                         tp_gather_partition_size=8,
-                        max_out_tokens=512):
+                        max_out_tokens=512,
+                        bf16=False):
 
     device = "cpu" if offload else "none"
     zero_opt_dict = {
@@ -35,8 +36,11 @@ def get_train_ds_config(offload,
         "steps_per_print": 10,
         "zero_optimization": zero_opt_dict,
         "fp16": {
-            "enabled": True,
+            "enabled": not bf16,
             "loss_scale_window": 100
+        },
+        "bfloat16": {
+            "enabled": bf16,
         },
         "gradient_clipping": 1.0,
         "prescale_gradients": False,
@@ -52,7 +56,7 @@ def get_train_ds_config(offload,
     }
 
 
-def get_eval_ds_config(offload, stage=0):
+def get_eval_ds_config(offload, stage=0, bf16=False):
     device = "cpu" if offload else "none"
     zero_opt_dict = {
         "stage": stage,
@@ -68,7 +72,10 @@ def get_eval_ds_config(offload, stage=0):
         "steps_per_print": 10,
         "zero_optimization": zero_opt_dict,
         "fp16": {
-            "enabled": True
+            "enabled": not bf16,
+        },
+        "bfloat16": {
+            "enabled": bf16,
         },
         "gradient_clipping": 1.0,
         "prescale_gradients": False,


### PR DESCRIPTION
This commit adds support for dtype=bfloat16 for all DeepSpeed-Chat training stages.
A new argument --bf16 was added to all training scripts. If not provided, the default is to use fp16 (as before).