### PR TITLE
Fix argparse

### DIFF
--- a/applications/DeepSpeed-Chat/training/step1_supervised_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step1_supervised_finetuning/main.py
@@ -46,8 +46,8 @@ def parse_args():
                         default='2,4,4',
                         help='Comma-separated list of proportions for training'
                         'phase 1, 2, and 3 data. For example the split `6,2,2`'
-                        'will use 60% of data for phase 1, 20% for phase 2'
-                        'and 20% for phase 3.')
+                        'will use 60%% of data for phase 1, 20%% for phase 2'
+                        'and 20%% for phase 3.')
     parser.add_argument(
         '--sft_only_data_path',
         nargs='*',

--- a/applications/DeepSpeed-Chat/training/step2_reward_model_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step2_reward_model_finetuning/main.py
@@ -44,8 +44,8 @@ def parse_args():
                         default='2,4,4',
                         help='Comma-separated list of proportions for training'
                         'phase 1, 2, and 3 data. For example the split `2,4,4`'
-                        'will use 60% of data for phase 1, 20% for phase 2'
-                        'and 20% for phase 3.')
+                        'will use 60%% of data for phase 1, 20%% for phase 2'
+                        'and 20%% for phase 3.')
     parser.add_argument(
         '--data_output_path',
         type=str,

--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
@@ -59,7 +59,7 @@ def parse_args():
         default='2,4,4',
         help=
         'Comma-separated list of proportions for training phase 1, 2, and 3 data. For example the split `2,4,4` '
-        'will use 60% of data for phase 1, 20% for phase 2 and 20% for phase 3.'
+        'will use 60%% of data for phase 1, 20%% for phase 2 and 20%% for phase 3.'
     )
     parser.add_argument(
         '--data_output_path',


### PR DESCRIPTION

## Bug

`python main.py --help`   has a bug

```sh
$ cd applications/DeepSpeed-Chat/training/step1_supervised_finetuning
$ python main.py --help
Traceback (most recent call last):
  File "main.py", line 351, in <module>
    main()
  File "main.py", line 177, in main
    args = parse_args()
  File "main.py", line 165, in parse_args
    args = parser.parse_args()
  File "/usr/lib/python3.8/argparse.py", line 1780, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/lib/python3.8/argparse.py", line 1812, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib/python3.8/argparse.py", line 2018, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/lib/python3.8/argparse.py", line 1958, in consume_optional
    take_action(action, args, option_string)
  File "/usr/lib/python3.8/argparse.py", line 1886, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/lib/python3.8/argparse.py", line 1056, in __call__
    parser.print_help()
  File "/usr/lib/python3.8/argparse.py", line 2506, in print_help
    self._print_message(self.format_help(), file)
  File "/usr/lib/python3.8/argparse.py", line 2490, in format_help
    return formatter.format_help()
  File "/usr/lib/python3.8/argparse.py", line 294, in format_help
    help = self._root_section.format_help()
  File "/usr/lib/python3.8/argparse.py", line 225, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.8/argparse.py", line 225, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.8/argparse.py", line 225, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.8/argparse.py", line 225, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.8/argparse.py", line 541, in _format_action
    help_text = self._expand_help(action)
  File "/usr/lib/python3.8/argparse.py", line 633, in _expand_help
    return self._get_help_string(action) % params
TypeError: %o format: an integer is required, not dict

```


## Related documents

https://thomas-cokelaer.info/blog/2014/03/python-argparse-issues-with-the-help-argument-typeerror-o-format-a-number-is-required-not-dict/

