### PR TITLE
Specify the dataset_name for the mkqa dataset.

### DIFF
--- a/applications/DeepSpeed-Chat/training/utils/data/data_utils.py
+++ b/applications/DeepSpeed-Chat/training/utils/data/data_utils.py
@@ -51,10 +51,10 @@ def get_raw_dataset(dataset_name, output_path, seed, local_rank):
             output_path, seed, local_rank, dataset_name)
     elif "mkqa-Chinese" in dataset_name:
         return raw_datasets.MkqaChineseDataset(output_path, seed, local_rank,
-                                               dataset_name)
+                                               "mkqa")
     elif "mkqa-Japanese" in dataset_name:
         return raw_datasets.MkqaJapaneseDataset(output_path, seed, local_rank,
-                                                dataset_name)
+                                                "mkqa")
     elif "Cohere/miracl-ja-queries-22-12" in dataset_name:
         return raw_datasets.CohereMiracljaqueries2212Dataset(
             output_path, seed, local_rank, dataset_name)


### PR DESCRIPTION
`mkqa-Japanese` and `mkqa-Chinese` are not present in the HuggingFace Dataset.

I think that all datasets related to mkqa need to be obtained from https://huggingface.co/datasets/mkqa.




