### PR TITLE
Fix get_prompt_and_rejected in CohereMiracljaqueries2212Dataset

### DIFF
--- a/applications/DeepSpeed-Chat/training/utils/data/raw_datasets.py
+++ b/applications/DeepSpeed-Chat/training/utils/data/raw_datasets.py
@@ -689,9 +689,10 @@ class CohereMiracljaqueries2212Dataset(PromptRawDataset):
             'positive_passages'][0]['text']
 
     def get_prompt_and_rejected(self, sample):
-        return " Human: " + sample['query'] + " Assistant: " + sample[
-            'negative_passages'][0]['text']
-
+        if len(sample['negative_passages']) > 0:
+            return " Human: " + sample['query'] + " Assistant: " + sample[
+                'negative_passages'][0]['text']
+        return None
 
 # Japanese dataset
 class LmqgQgjaquadDataset(PromptRawDataset):


### PR DESCRIPTION
`negative_passages` length for CohereMiracljaqueries2212Dataset may be 0.
Below is an example.
https://huggingface.co/datasets/Cohere/miracl-ja-queries-22-12/viewer/Cohere--miracl-ja-queries-22-12/train?row=2