### PR TITLE
DS Chat Step 3 - Add separate Lora Adam optimizer group

### DIFF
--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/training_scripts/single_node/run_1.3b_lora.sh
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/training_scripts/single_node/run_1.3b_lora.sh
@@ -14,7 +14,7 @@ OUTPUT="./output"
 
 Num_Padding_at_Beginning=1 # this is model related
 
-Actor_Lr=5e-4
+Actor_Lr=9.65e-6
 Critic_Lr=5e-6
 
 mkdir -p $OUTPUT

--- a/applications/DeepSpeed-Chat/training/utils/utils.py
+++ b/applications/DeepSpeed-Chat/training/utils/utils.py
@@ -92,18 +92,36 @@ def get_all_reduce_mean(tensor):
 
 def get_optimizer_grouped_parameters(model,
                                      weight_decay,
+                                     lora_lr=5e-4,
                                      no_decay_name_list=[
                                          "bias", "LayerNorm.weight"
-                                     ]):
+                                     ],
+                                     lora_name_list=[
+                                         "lora_right_weight", "lora_left_weight"
+                                     ],
+                                     ):
     optimizer_grouped_parameters = [
         {
             "params": [
                 p for n, p in model.named_parameters()
                 if (not any(nd in n
-                            for nd in no_decay_name_list) and p.requires_grad)
+                            for nd in no_decay_name_list) and p.requires_grad
+                    and not any(nd in n for nd in lora_name_list))
             ],
             "weight_decay":
             weight_decay,
+        },
+        {
+            "params": [
+                p for n, p in model.named_parameters()
+                if (not any(nd in n
+                            for nd in no_decay_name_list) and p.requires_grad
+                    and any(nd in n for nd in lora_name_list))
+            ],
+            "weight_decay":
+            weight_decay,
+            "lr":
+            lora_lr
         },
         {
             "params": [
@@ -115,6 +133,8 @@ def get_optimizer_grouped_parameters(model,
             0.0,
         },
     ]
+    if not optimizer_grouped_parameters[1]["params"]:
+        optimizer_grouped_parameters.pop(1)
     return optimizer_grouped_parameters
 
 

--- a/applications/DeepSpeed-Chat/training/utils/utils.py
+++ b/applications/DeepSpeed-Chat/training/utils/utils.py
@@ -90,23 +90,20 @@ def get_all_reduce_mean(tensor):
     return tensor
 
 
-def get_optimizer_grouped_parameters(model,
-                                     weight_decay,
-                                     lora_lr=5e-4,
-                                     no_decay_name_list=[
-                                         "bias", "LayerNorm.weight"
-                                     ],
-                                     lora_name_list=[
-                                         "lora_right_weight", "lora_left_weight"
-                                     ],
-                                     ):
+def get_optimizer_grouped_parameters(
+    model,
+    weight_decay,
+    lora_lr=5e-4,
+    no_decay_name_list=["bias", "LayerNorm.weight"],
+    lora_name_list=["lora_right_weight", "lora_left_weight"],
+):
     optimizer_grouped_parameters = [
         {
             "params": [
                 p for n, p in model.named_parameters()
-                if (not any(nd in n
-                            for nd in no_decay_name_list) and p.requires_grad
-                    and not any(nd in n for nd in lora_name_list))
+                if (not any(nd in n for nd in no_decay_name_list)
+                    and p.requires_grad and not any(nd in n
+                                                    for nd in lora_name_list))
             ],
             "weight_decay":
             weight_decay,
@@ -114,9 +111,9 @@ def get_optimizer_grouped_parameters(model,
         {
             "params": [
                 p for n, p in model.named_parameters()
-                if (not any(nd in n
-                            for nd in no_decay_name_list) and p.requires_grad
-                    and any(nd in n for nd in lora_name_list))
+                if (not any(nd in n for nd in no_decay_name_list)
+                    and p.requires_grad and any(nd in n
+                                                for nd in lora_name_list))
             ],
             "weight_decay":
             weight_decay,


### PR DESCRIPTION
This PR adds a separate Lora Adam optimizer group (for `lora_right_weight` and `lora_left_weight` params) with a Lora-specific learning rate of `lr=5e-4`. After this change, Step 3 training convergence with Lora enabled improved across various configurations when using zero stage 2.

Thanks to @yaozhewei for the insight!

**BEFORE:**
![image](https://github.com/microsoft/DeepSpeedExamples/assets/113481193/ac17a87d-10c9-4781-bdae-b0a53641ad00)

**AFTER:**
![image](https://github.com/microsoft/DeepSpeedExamples/assets/113481193/198bd759-99fd-46af-85a6-847a71ae0690)
