### PR TITLE
DS Chat Step 3 - Fix Zero Stage 3

### DIFF
--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/ppo_trainer.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/ppo_trainer.py
@@ -56,6 +56,7 @@ class DeepSpeedPPOTrainer():
         self.max_answer_seq_len = args.max_answer_seq_len
         self.end_of_conversation_token_id = self.tokenizer(
             args.end_of_conversation_token)['input_ids'][-1]
+        self.z3_enabled = args.actor_zero_stage == 3
 
         # Those value can be changed
         self.kl_ctl = 0.1
@@ -75,7 +76,7 @@ class DeepSpeedPPOTrainer():
                 attention_mask=mask,
                 max_length=max_min_length,
                 pad_token_id=self.tokenizer.pad_token_id,
-                #    min_length=max_min_length
+                synced_gpus=self.z3_enabled
             )
 
         # Filter out seq with no answers (or very short). This happens when users directly use the pre-training ckpt without supervised finetuning

--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/ppo_trainer.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/ppo_trainer.py
@@ -76,8 +76,7 @@ class DeepSpeedPPOTrainer():
                 attention_mask=mask,
                 max_length=max_min_length,
                 pad_token_id=self.tokenizer.pad_token_id,
-                synced_gpus=self.z3_enabled
-            )
+                synced_gpus=self.z3_enabled)
 
         # Filter out seq with no answers (or very short). This happens when users directly use the pre-training ckpt without supervised finetuning
         # NOTE: this will causes each GPU has different number of examples


### PR DESCRIPTION
This PR fixes Zero Stage 3 (Z3) for DS Chat step 3 by setting `synced_gpus=True` in the `ppo_trainer` `self.actor_model.module.generate(...)` call when Z3 is enabled for the actor model. Prior to this fix, Z3 enabled actor models would hang during DS Chat step 3 training.

TODO: Update `transformers` automatic Z3 detection to work with DS Chat pipeline.

Thanks to @jeffra and @tjruwase.