### PR TITLE
Update DS Chat transformers req

### DIFF
--- a/applications/DeepSpeed-Chat/requirements.txt
+++ b/applications/DeepSpeed-Chat/requirements.txt
@@ -4,4 +4,4 @@ protobuf==3.20.3
 accelerate>=0.15.0
 torch>=1.12.0
 deepspeed>=0.9.0
-git+https://github.com/huggingface/transformers
+transformers>=4.31

--- a/applications/DeepSpeed-Chat/requirements.txt
+++ b/applications/DeepSpeed-Chat/requirements.txt
@@ -4,4 +4,4 @@ protobuf==3.20.3
 accelerate>=0.15.0
 torch>=1.12.0
 deepspeed>=0.9.0
-transformers>=4.31
+transformers>=4.31.0


### PR DESCRIPTION
This PR updates the `transformers` requirement in DS Chat to `transformers>=4.31.0`.