### PR TITLE
Fix output arg in step 3 llama script

### DIFF
--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/training_scripts/single_node/run_7b_llama.sh
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/training_scripts/single_node/run_7b_llama.sh
@@ -7,7 +7,7 @@ ACTOR_MODEL_PATH=$1
 CRITIC_MODEL_PATH=$2
 ACTOR_ZERO_STAGE=$3
 CRITIC_ZERO_STAGE=$4
-OUTPUT=$3
+OUTPUT=$5
 if [ "$OUTPUT" == "" ]; then
     OUTPUT=./output_step3_llama
 fi


### PR DESCRIPTION
This PR fixes the `OUTPUT` arg in the step 3 llama script to use the proper arg position.