### PR TITLE
Potential Bugs:  `ends` in `ppo_trainer.py`

### DIFF
--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/ppo_trainer.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/ppo_trainer.py
@@ -142,7 +142,7 @@ class DeepSpeedPPOTrainer():
         kl_divergence_estimate = -self.kl_ctl * (log_probs - ref_log_probs)
         rewards = kl_divergence_estimate
         start = prompts.shape[1] - 1
-        ends = start + action_mask[:, start:].sum(1) + 1
+        ends = start + action_mask[:, start:].sum(1)
         reward_clip = torch.clamp(reward_score, -self.clip_reward_value,
                                   self.clip_reward_value)
         batch_size = log_probs.shape[0]
@@ -170,7 +170,7 @@ class DeepSpeedPPOTrainer():
             old_rewards = self.compute_rewards(prompts, log_probs,
                                                ref_log_probs, reward_score,
                                                action_mask)
-            ends = start + action_mask[:, start:].sum(1) + 1
+            ends = start + action_mask[:, start:].sum(1)
             # we need to zero out the reward and value after the end of the conversation
             # otherwise the advantage/return will be wrong
             for i in range(old_rewards.shape[0]):


### PR DESCRIPTION
Currently, `ends = start + action_mask[:, start:].sum(1) + 1` points to the right of `<eos>`. But it seems like we should also zero out the reward and value **at** `<eos>`.

In practice, we can see why `ends = start + action_mask[:, start:].sum(1) + 1` is not optimal by adding a sanity check.
```
assert (advantages[0] != 0).sum().item() == action_mask[0, start:].sum().item()
```
For the current version of ppo_trainer.py, the return of LHS is always equal to RHS + 1, which means there is one trailing reward/value not zeroed out. 