### PR TITLE
Add test mode args to DS Chat step 3

### DIFF
--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
@@ -306,6 +306,18 @@ def parse_args():
     parser.add_argument('--print_answers',
                         action='store_true',
                         help='Print prompt and answers during training')
+    ## Testing
+    parser.add_argument(
+        '--enable_test_mode',
+        action='store_true',
+        help=
+        'Enable a testing mode that terminates training based on args.test_stop_step'
+    )
+    parser.add_argument(
+        "--test_stop_step",
+        type=int,
+        default=0,
+        help="Training step at which to terminate training during testing.")
 
     parser = deepspeed.add_config_arguments(parser)
     args = parser.parse_args()
@@ -520,6 +532,12 @@ def main():
 
             if args.actor_gradient_checkpointing:
                 rlhf_engine.actor.gradient_checkpointing_disable()
+
+            if args.enable_test_mode and step == args.test_stop_step:
+                break
+
+        if args.enable_test_mode:
+            break
 
     if args.output_dir is not None:
         print_rank_0('saving model ...')


### PR DESCRIPTION
This PR adds two test mode arguments to DS Chat step 3 training:
1. `enable_test_mode` - Enable a testing mode that terminates training based on args.test_stop_step
2. `test_stop_step` - Training step at which to terminate training during testing.