### PR TITLE
Remove skipping of Z3 case in DS Chat step 3 training

### DIFF
--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
@@ -356,11 +356,6 @@ def parse_args():
             "The combination of [actor_zero_stage==2, critic_zero_stage==2, enable_hybrid_engine=True, offload=True, lora=False] is currently unsupported due to training instability!"
         )
 
-    if args.actor_zero_stage == 3 and args.critic_zero_stage == 3 and args.enable_hybrid_engine and args.offload and args.actor_lora_dim > 0:
-        raise ValueError(
-            "The combination of [actor_zero_stage==3, critic_zero_stage==3, enable_hybrid_engine=True, offload=True, lora=True] is currently unsupported due to training instability!"
-        )
-
     return args
 
 

--- a/applications/DeepSpeed-Chat/training/tests/test_training.py
+++ b/applications/DeepSpeed-Chat/training/tests/test_training.py
@@ -60,11 +60,6 @@ def test_ds_chat(zero_stage, hybrid_engine, offload, lora):
             "The combination of [actor_zero_stage==2, critic_zero_stage==2, enable_hybrid_engine=True, offload=True, lora=False] is currently unsupported due to training instability!"
         )
 
-    if zero_stage == "3" and hybrid_engine == "true" and offload == "true" and lora == "true":
-        pytest.skip(
-            "The combination of [actor_zero_stage==3, critic_zero_stage==3, enable_hybrid_engine=True, offload=True, lora=True] is currently unsupported due to training instability!"
-        )
-
     # cd into execution dir
     wd = os.getcwd()
     os.chdir("../step3_rlhf_finetuning")


### PR DESCRIPTION
This PR removes skipping of the `zero_stage == "3" and hybrid_engine == "true" and offload == "true" and lora == "true"` case since the training instability was determined to be transient. This case is now supported by DS Chat step 3 training and is tested in the DS Chat PyTest.