### PR TITLE
add torch.distributed.init_process_group() for rw_eval.py

### DIFF
--- a/applications/DeepSpeed-Chat/training/step2_reward_model_finetuning/rw_eval.py
+++ b/applications/DeepSpeed-Chat/training/step2_reward_model_finetuning/rw_eval.py
@@ -101,6 +101,11 @@ def run_pair_comparison():
     args = parse_args()
 
     device = torch.device("cuda:0")
+    os.environ['RANK'] = '0'
+    os.environ['WORLD_SIZE'] = '1'
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = '8888'
+    torch.distributed.init_process_group() 
 
     rm_model, tokenizer = load_stuff(args.model_name_or_path,
                                      args.num_padding_at_beginning)
@@ -144,8 +149,14 @@ def run_pair_comparison():
 
 def run_single_sample():
     args = parse_args()
-    device = torch.device("cuda")
 
+    device = torch.device("cuda:0")
+    os.environ['RANK'] = '0'
+    os.environ['WORLD_SIZE'] = '1'
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = '8888'
+    torch.distributed.init_process_group()
+    
     rm_model, tokenizer = load_stuff(args.model_name_or_path,
                                      args.num_padding_at_beginning)
     rm_model.to(device)


### PR DESCRIPTION
While using the latest version branch, I encountered an error `RuntimeError: Default process group has not been initialized, please make sure to call init_process_group.` when trying to run the `rw_eval.py` script using the provided `bash evaluation_scripts/run_eval.sh` script from the README. The error details is:
```bash
root@oneflow-27:/workspace/dev/DeepSpeedExamples/applications/DeepSpeed-Chat/training/step2_reward_model_finetuning# bash evaluation_scripts/run_eval.sh
[2023-08-17 09:22:44,086] [INFO] [real_accelerator.py:133:get_accelerator] Setting ds_accelerator to cuda (auto detect)
Traceback (most recent call last):
  File "rw_eval.py", line 189, in <module>
    run_pair_comparison()
  File "rw_eval.py", line 110, in run_pair_comparison
    rm_model, tokenizer = load_stuff(args.model_name_or_path,
  File "rw_eval.py", line 45, in load_stuff
    model = create_critic_model(model_name_or_path, tokenizer, None,
  File "/workspace/dev/DeepSpeedExamples/applications/DeepSpeed-Chat/training/utils/model/model_utils.py", line 68, in create_critic_model
    if torch.distributed.get_rank() == 0:
  File "/workspace/dev/DeepSpeedExamples/applications/DeepSpeed-Chat/venv_/lib/python3.8/site-packages/torch/distributed/distributed_c10d.py", line 1173, in get_rank
    default_pg = _get_default_group()
  File "/workspace/dev/DeepSpeedExamples/applications/DeepSpeed-Chat/venv_/lib/python3.8/site-packages/torch/distributed/distributed_c10d.py", line 707, in _get_default_group
    raise RuntimeError(
RuntimeError: Default process group has not been initialized, please make sure to call init_process_group.
```
<br>

Adding `torch.distributed.init_process_group()`  can resolve this issue.