### PR TITLE
Filter transformers version 4.33.2 due to bug

### DIFF
--- a/applications/DeepSpeed-Chat/requirements.txt
+++ b/applications/DeepSpeed-Chat/requirements.txt
@@ -4,5 +4,5 @@ protobuf==3.20.3
 accelerate>=0.15.0
 torch>=1.12.0
 deepspeed>=0.9.0
-transformers>=4.31.0
+transformers>=4.31.0,!=4.33.2
 tensorboard


### PR DESCRIPTION
Performance metrics in DeepSpeed-Chat were broken with `transformers` version 4.33.2, so that version is explicitly filtered out in the DeepSpeed-Chat `requirements.txt`. This will fix the currently broken [nv-ds-chat](https://github.com/microsoft/DeepSpeed/actions/workflows/nv-ds-chat.yml) workflow.

The issue is recently fixed in this HuggingFace `transformers` [PR](https://github.com/huggingface/transformers/pull/26102/files), so this will not be a problem in the next `transformers` release.

Manual `nv-ds-chat` workflow run:
https://github.com/microsoft/DeepSpeed/actions/runs/6241048578