### PR TITLE
[DeepSpeedChat]support other runners like MPICH to run the DeepSpeed-Chat on multi-ranks.

### DIFF
--- a/applications/DeepSpeed-Chat/training/step1_supervised_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step1_supervised_finetuning/main.py
@@ -204,6 +204,7 @@ def parse_args():
 def main():
     args = parse_args()
 
+    args.local_rank = int(os.getenv("RANK"))
     if args.local_rank == -1:
         device = torch.device(get_accelerator().device_name())
     else:

--- a/applications/DeepSpeed-Chat/training/step2_reward_model_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step2_reward_model_finetuning/main.py
@@ -210,6 +210,7 @@ def parse_args():
 def main():
     args = parse_args()
 
+    args.local_rank = int(os.getenv("RANK"))
     if args.local_rank == -1:
         device = torch.device(get_accelerator().device_name())
     else:

--- a/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step3_rlhf_finetuning/main.py
@@ -437,6 +437,7 @@ def create_datasets(args, tokenizer, train_phase=3):
 def main():
     args = parse_args()
 
+    args.local_rank = int(os.getenv("RANK"))
     if args.local_rank == -1:
         device = torch.device(get_accelerator().device_name())
     else:


### PR DESCRIPTION
DeepSpeed can support different runners like MPICH, if we run the DeepSpeedChat with MPICH, local rank won't get the value, add this to get values from environment can support some other runners like MPICH, not only for deepspeed launch when run for multi-nodes.