### PR TITLE
Update transformers dependency in deepspeed-chat install

### DIFF
--- a/applications/DeepSpeed-Chat/setup.py
+++ b/applications/DeepSpeed-Chat/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     install_requires=[
         "datasets>=2.8.0", "sentencepiece>=0.1.97", "protobuf==3.20.3",
         "accelerate>=0.15.0", "torch>=1.12.0", "deepspeed>=0.9.2",
-        "transformers", "tensorboard"
+        "transformers>=4.31.0,!=4.33.2", "tensorboard"
     ],
     extras_require={
         "azureml": [


### PR DESCRIPTION
Updates `deepspeed-chat` package install transformer dependency to `"transformers>=4.31.0,!=4.33.2"`.