### PR TITLE
fix: using DistributedSampler when evaluating the reward model

### DIFF
--- a/applications/DeepSpeed-Chat/training/step2_reward_model_finetuning/main.py
+++ b/applications/DeepSpeed-Chat/training/step2_reward_model_finetuning/main.py
@@ -291,7 +291,6 @@ def main():
                                   collate_fn=data_collator,
                                   sampler=train_sampler,
                                   batch_size=args.per_device_train_batch_size)
-    eval_sampler = SequentialSampler(eval_dataset)
     eval_dataloader = DataLoader(eval_dataset,
                                  collate_fn=data_collator,
                                  sampler=eval_sampler,


### PR DESCRIPTION
![image](https://github.com/microsoft/DeepSpeedExamples/assets/30254428/82781208-9866-4f9c-bffc-e542d4084e84)

The `eval_sampler` defined at line 294 is redundant since it was previously established. Moreover, redefining it leads to each rank evaluating the entire dataset, which is an inefficient use of computational resources and slows down the evaluation.