### PR TITLE
Fix SD example imports for latest diffusers

### DIFF
--- a/inference/huggingface/stable-diffusion/local_pipeline_stable_diffusion.py
+++ b/inference/huggingface/stable-diffusion/local_pipeline_stable_diffusion.py
@@ -29,11 +29,12 @@ from diffusers.utils import (
     is_accelerate_available,
     is_accelerate_version,
     logging,
-    randn_tensor,
     replace_example_docstring,
 )
 
-from diffusers.pipeline_utils import DiffusionPipeline
+from diffusers.utils.torch_utils import randn_tensor
+
+from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from diffusers.pipelines.stable_diffusion import StableDiffusionPipelineOutput
 from diffusers.pipelines.stable_diffusion.safety_checker import StableDiffusionSafetyChecker
 

--- a/inference/huggingface/stable-diffusion/requirements.txt
+++ b/inference/huggingface/stable-diffusion/requirements.txt
@@ -1,4 +1,4 @@
 deepspeed
 torch
-diffusers
+diffusers>=0.22.3
 triton==2.0.0.dev20221202


### PR DESCRIPTION
This PR fixes a few `diffusers` library imports in our Stable Diffusion example.