### PR TITLE
Add Human Eval Example

### DIFF
--- a/evaluation/inference/human_eval/README.md
+++ b/evaluation/inference/human_eval/README.md
@@ -12,7 +12,7 @@ which requires local changes to `execution.py`. The following steps will setup `
 
 ```bash
 git clone https://github.com/openai/human-eval.git
-sed -i 's/.*#                         exec(check_program, exec_globals).*/                        exec(check_program, exec_globals)/' human-eval/human_eval/execution.py
+sed -i '/exec(check_program, exec_globals)/ s/^# //' he_test/human_eval/execution.py
 cd human-eval
 python -m pip install -e .
 ```

--- a/evaluation/inference/human_eval/README.md
+++ b/evaluation/inference/human_eval/README.md
@@ -1,0 +1,45 @@
+# HumanEval Evaluation Script for DeepSpeed-FastGen
+
+## DISCLAIMER
+
+This human-eval evaluation will execute untrusted model-generated code. As per the OpenAI warning, we
+strongly recommend you sandbox your environment as described in the [human-eval paper](https://arxiv.org/pdf/2107.03374.pdf).
+
+## Setup
+
+Running the human-eval evaluation requires installation of `human_eval` with the execution code enabled,
+which requires local changes to `execution.py`. The following steps will setup `human-eval` for execution:
+
+```bash
+git clone https://github.com/openai/human-eval.git
+sed -i 's/.*#                         exec(check_program, exec_globals).*/                        exec(check_program, exec_globals)/' human-eval/human_eval/execution.py
+cd human-eval
+python -m pip install -e .
+```
+
+This evaluation also requires the installation of DeepSpeed-MII:
+
+```bash
+python -m pip install deepspeed-mii
+```
+
+Additional DeepSpeed-MII installation details can be found [here](https://github.com/microsoft/DeepSpeed-MII#installation).
+
+## Run the Evaluation
+
+The following command shows how to run a benchmark using the `facebook/opt-6.7b` model:
+
+```bash
+python run_human_eval.py --model facebook/opt-6.7b --max-tokens 256 --num-samples-per-task 10
+```
+
+## Run Evaluation on Samples
+
+Once samples have been generated, they can be evaluated independently using the `evaluate_functional_correctness` command.
+For example, the following command will evaluate `mii_samples.jsonl`:
+
+```bash
+evaluate_functional_correctness mii_samples.jsonl
+```
+
+The evaluation results will be saved to `mii_samples.jsonl_results.jsonl`.

--- a/evaluation/inference/human_eval/README.md
+++ b/evaluation/inference/human_eval/README.md
@@ -27,10 +27,10 @@ Additional DeepSpeed-MII installation details can be found [here](https://github
 
 ## Run the Evaluation
 
-The following command shows how to run a benchmark using the `facebook/opt-6.7b` model:
+The following command shows how to run a benchmark using the `codellama/CodeLlama-7b-Python-hf` model:
 
 ```bash
-python run_human_eval.py --model facebook/opt-6.7b --max-tokens 256 --num-samples-per-task 10
+python run_human_eval.py --model codellama/CodeLlama-7b-Python-hf --max-tokens 512 --num-samples-per-task 20
 ```
 
 ## Run Evaluation on Samples

--- a/evaluation/inference/human_eval/run_human_eval.py
+++ b/evaluation/inference/human_eval/run_human_eval.py
@@ -40,8 +40,7 @@ print("Initializing DeepSpeed-MII Pipeline")
 mii_pipe = mii.pipeline(args.model)
 
 print("Loading Problems")
-#problems = read_problems("human-eval/data/HumanEval.jsonl.gz")
-problems = read_problems("human-eval/data/HumanEvalTest.jsonl.gz")
+problems = read_problems("human-eval/data/HumanEval.jsonl.gz")
 
 print("Generating Base Samples")
 base_samples = generate_samples(generate_base_completion)

--- a/evaluation/inference/human_eval/run_human_eval.py
+++ b/evaluation/inference/human_eval/run_human_eval.py
@@ -1,0 +1,66 @@
+import os
+import torch
+import mii
+import numpy
+import argparse
+from deepspeed.accelerator import get_accelerator
+from transformers import pipeline
+from human_eval.data import write_jsonl, read_problems
+from human_eval.evaluation import evaluate_functional_correctness
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--model", "-m", type=str, help="evaluation model name")
+parser.add_argument("--max-tokens", type=int, default=256, help="max new tokens")
+parser.add_argument("--num-samples-per-task", type=int, default=10, help="number of samples to gen/eval per task")
+parser.add_argument("--local_rank", type=int, default=int(os.getenv("LOCAL_RANK", "0")), help="local rank")
+args = parser.parse_args()
+
+def generate_base_completion(problem_prompt: str) -> str:
+    return base_pipe(problem_prompt, do_sample=True)[0]["generated_text"]
+
+def generate_mii_completion(problem_prompt: str) -> str:
+    return mii_pipe(problem_prompt, max_new_tokens=args.max_tokens)[0].generated_text
+
+def generate_samples(generation_function):
+    samples = [
+        dict(task_id=task_id, completion=generation_function(problems[task_id]["prompt"])) for task_id in problems
+        for _ in range(args.num_samples_per_task)
+    ]
+    return samples
+# TODO (lekurile): Move these functions to utils in DSE repo (TBD)
+
+print("Initializing HuggingFace Pipeline")
+device = torch.device(get_accelerator().device_name(args.local_rank))
+base_pipe = pipeline(model=args.model,
+                        device=torch.device(get_accelerator().device_name(args.local_rank)),
+                        max_length=args.max_tokens,
+                        return_full_text=False)
+
+print("Initializing DeepSpeed-MII Pipeline")
+mii_pipe = mii.pipeline(args.model)
+
+print("Loading Problems")
+#problems = read_problems("human-eval/data/HumanEval.jsonl.gz")
+problems = read_problems("human-eval/data/HumanEvalTest.jsonl.gz")
+
+print("Generating Base Samples")
+base_samples = generate_samples(generate_base_completion)
+
+print("Generating MII Samples")
+mii_samples = generate_samples(generate_mii_completion)
+
+print("Writing Samples")
+write_jsonl("base_samples.jsonl", base_samples)
+write_jsonl("mii_samples.jsonl", mii_samples)
+
+print("Evaluating Samples")
+base_results = evaluate_functional_correctness("base_samples.jsonl")
+mii_results = evaluate_functional_correctness("mii_samples.jsonl")
+
+print(f"Base Results = {base_results}")
+print(f"MII Results = {mii_results}")
+
+print("Executing Assertions")
+for key in base_results.keys():
+    assert numpy.allclose(base_results[key], mii_results[key], rtol=0.2), \
+        f"Base result: {base_results[key]}, MII result: {mii_results[key]}, outside of rtol."


### PR DESCRIPTION
This PR adds a HumanEval example and an associated README. The example will run through the `human-eval` problem set using a standard HuggingFace Pipeline and DeepSpeed-MII's FastGen, performing a simple result comparison at the end.

A new `evaluation` folder is added to `DeepSpeedExamples` more generally to house evaluation scripts.