### PR TITLE
Fix path in human-eval example README

### DIFF
--- a/evaluation/inference/human_eval/README.md
+++ b/evaluation/inference/human_eval/README.md
@@ -12,7 +12,7 @@ which requires local changes to `execution.py`. The following steps will setup `
 
 ```bash
 git clone https://github.com/openai/human-eval.git
-sed -i '/exec(check_program, exec_globals)/ s/^# //' he_test/human_eval/execution.py
+sed -i '/exec(check_program, exec_globals)/ s/^# //' human-eval/human_eval/execution.py
 cd human-eval
 python -m pip install -e .
 ```


### PR DESCRIPTION
Fix `sed` path in human-eval example README.