### PR TITLE
Update Inference Benchmarking Scripts - Support AML

### DIFF
--- a/benchmarks/inference/mii/README.md
+++ b/benchmarks/inference/mii/README.md
@@ -52,12 +52,19 @@ Results are collected in `./results/`.
 ## Analyze the Benchmark Results
 
 The scripts mentioned below were used for generating the plots featured in our
-blog. Specify the root directory for log files using `--log_dir`. The generated
+blog. Specify the root directory for log files using `--log_dir` and the backends you wish to run for, e.g. `--backend vllm fastgen aml`. The generated
 figures will be saved to `./plots/`
 
 - `src/plot_th_lat.py`: This script generates charts for throughput and latency across different model sizes and client counts.
 - `src/plot_effective_throughput.py`: Use this to chart effective throughput.
 - `src/plot_latency_percentile.py`: This script will plot the 50th, 90th, and 95th percentile latencies.
+- `src/plot_repl_scale.py`: This script will plot the throughput and number of replicas for a fixed clients/replica per plot.
+- `src/plot_tp_sizes.py`: This script will plot latency and TFLOPs per GPU across different tensor parallelism sizes.
+
+The following command shows an example of `plot_th_lat.py` execution using the `vllm`, `fastgen`, and `aml` backends.
+```bash
+DeepSpeedExamples/benchmarks/inference/mii$ python3 src/plot_th_lat.py --backend vllm fastgen aml --log_dir results/
+```
 
 ## Running an End-to-End Example
 

--- a/benchmarks/inference/mii/requirements.txt
+++ b/benchmarks/inference/mii/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 deepspeed-mii>=0.2.0
 vllm>=0.2.7
 numpy
+tabulate

--- a/benchmarks/inference/mii/src/plot_effective_throughput.py
+++ b/benchmarks/inference/mii/src/plot_effective_throughput.py
@@ -27,6 +27,7 @@ prompt_gen_pairs_all = [
     (2600, 60),
     (2600, 128),
 ]
+# TODO: Remove hardcoded values, generalize, source from logs
 
 prompt_gen_pairs_test = [(2600, 60)]
 
@@ -237,6 +238,8 @@ if __name__ == "__main__":
     raise NotImplementedError("This script is not up to date")
     args = get_args()
 
+    # TODO: Generalize this
+    # TODO: carry over code from plot_th_lat.py
     if args.test:
         tp_sizes = tp_sizes_test
         prompt_gen_pairs = prompt_gen_pairs_test
@@ -248,6 +251,7 @@ if __name__ == "__main__":
         for tp in tps:
             for prompt, gen in prompt_gen_pairs:
                 for sla_token_gen in SLA_GEN_TOKENS_PER_SEC:
+                    # TODO: standardize names
                     display_results(
                         model_size,
                         tp,

--- a/benchmarks/inference/mii/src/plot_effective_throughput.py
+++ b/benchmarks/inference/mii/src/plot_effective_throughput.py
@@ -17,7 +17,7 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
                         nargs="+", help="Specify the backends to generate plots for")
-    parser.add_argument("--log_dir", type=Path, default=".")
+    parser.add_argument("--log_dir", type=Path, default="./results")
     parser.add_argument("--out_dir", type=Path, default="./plots/goodtput")
     parser.add_argument("--sla_prompt_tokens_per_sec", type=int, default=512, help="SLA prompt tokens per second")
     parser.add_argument("--sla_gen_tokens_per_sec", type=int, default=[1, 2, 3, 4, 6, 8], nargs="+", help="SLA generation tokens/s targets")

--- a/benchmarks/inference/mii/src/plot_effective_throughput.py
+++ b/benchmarks/inference/mii/src/plot_effective_throughput.py
@@ -117,7 +117,7 @@ def extract_values(file_pattern, sla_token_gen, validate_func, sla_prompt_tokens
     return goodputs, good_ratios
 
 
-def output_charts(model, tp_size, bs, replicas, sla_token_gen, prompt, gen, log_dir, out_dir):
+def output_charts(args, model, tp_size, bs, replicas, sla_token_gen, prompt, gen, log_dir, out_dir):
     if not log_dir.exists():
         print(f"Log directory {log_dir} does not exist")
         return
@@ -136,8 +136,8 @@ def output_charts(model, tp_size, bs, replicas, sla_token_gen, prompt, gen, log_
         (validate_token_ema_latency_SLA, (args.ema_span,), f"ema{args.ema_span}"),
     ]
 
-    labels = {'fastgen': 'DeepSpeed-FastGen', 'vllm': 'vLLM'}
-    markers = {'fastgen': 'o', 'vllm': 'x'}
+    plt_cfg = {'vllm': {'label': 'vLLM', 'marker': 'x', 'color': 'orange'},\
+               'fastgen': {'label': 'DeepSpeed-FastGen', 'marker': 'o', 'color': 'blue'}}
 
     for f in validate_funcs:
         plt.figure()
@@ -154,8 +154,9 @@ def output_charts(model, tp_size, bs, replicas, sla_token_gen, prompt, gen, log_
             plt.scatter(
                 client_num_list,
                 goodputs_list,
-                label=labels[backend],
-                marker=markers[backend],
+                label=plt_cfg[backend]['label'],
+                marker=plt_cfg[backend]['marker'],
+                color=plt_cfg[backend]['color'],
             )
 
             fit_x_list = np.arange(min(client_num_list), max(client_num_list), 0.1)
@@ -166,6 +167,7 @@ def output_charts(model, tp_size, bs, replicas, sla_token_gen, prompt, gen, log_
                 model_fn(fit_x_list),
                 alpha=0.5,
                 linestyle="--",
+                color=plt_cfg[backend]['color'],
             )
 
         title = (
@@ -197,6 +199,7 @@ if __name__ == "__main__":
     for model, tp_size, bs, replicas, prompt, gen in result_params:
         for sla_token_gen in args.sla_gen_tokens_per_sec:
              output_charts(
+                args=args,
                 model=model,
                 tp_size=tp_size,
                 bs=bs,

--- a/benchmarks/inference/mii/src/plot_effective_throughput.py
+++ b/benchmarks/inference/mii/src/plot_effective_throughput.py
@@ -15,7 +15,7 @@ from postprocess_results import read_json, get_tokenizer, get_result_sets
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
+    parser.add_argument("--backend", type=str, choices=["fastgen", "vllm"], default=["fastgen", "vllm"], \
                         nargs="+", help="Specify the backends to generate plots for")
     parser.add_argument("--log_dir", type=Path, default="./results")
     parser.add_argument("--out_dir", type=Path, default="./plots/goodtput")
@@ -196,10 +196,6 @@ def output_charts(model, tp_size, bs, replicas, sla_token_gen, prompt, gen, log_
                 linestyle="--",
             )
 
-        if "aml" in args.backend:
-            # TODO (lekurile): Add AML code here if/when streaming is supported
-            raise NotImplementedError("Effective throughput analysis is not supported for AML.")
-
         title = (
             f"Effective throughput (SLA prompt: {args.sla_prompt_tokens_per_sec} tokens/s, generation: {sla_token_gen} tokens/s)\n"
             + f"Model: {model} Prompt: {prompt}, Generation: {gen}, TP: {tp_size}"
@@ -221,6 +217,8 @@ def output_charts(model, tp_size, bs, replicas, sla_token_gen, prompt, gen, log_
 
 if __name__ == "__main__":
     args = get_args()
+
+    assert "aml" not in args.backend, "Effective throughput analysis is not supported for AML."
 
     result_params = get_result_sets(args)
 

--- a/benchmarks/inference/mii/src/plot_effective_throughput.py
+++ b/benchmarks/inference/mii/src/plot_effective_throughput.py
@@ -10,34 +10,18 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from .postprocess_results import read_json, get_tokenizer
-
-RAGGED_BATCH_SIZE = 768
-SLA_PROMPT_TOKENS_PER_SEC = 512
-SLA_GEN_TOKENS_PER_SEC = [1, 2, 3, 4, 6, 8]
-EMA_SPAN = 16
-
-tp_sizes_all = {"7b": [1], "70b": [4, 8]}
-
-tp_sizes_test = {"7b": [1]}
-
-prompt_gen_pairs_all = [
-    (1200, 60),
-    (1200, 128),
-    (2600, 60),
-    (2600, 128),
-]
-# TODO: Remove hardcoded values, generalize, source from logs
-
-prompt_gen_pairs_test = [(2600, 60)]
+from postprocess_results import read_json, get_tokenizer, get_result_sets
 
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--test", action="store_true")
-    parser.add_argument("--no_vllm", action="store_true")
+    parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
+                        nargs="+", help="Specify the backends to generate plots for")
     parser.add_argument("--log_dir", type=Path, default=".")
-    parser.add_argument("--out_dir", type=Path, default="charts/goodtput")
+    parser.add_argument("--out_dir", type=Path, default="./plots/goodtput")
+    parser.add_argument("--sla_prompt_tokens_per_sec", type=int, default=512, help="SLA prompt tokens per second")
+    parser.add_argument("--sla_gen_tokens_per_sec", type=int, default=[1, 2, 3, 4, 6, 8], nargs="+", help="SLA generation tokens/s targets")
+    parser.add_argument("--ema_span", type=int, default=16, help="EMA span")
     args = parser.parse_args()
     return args
 
@@ -91,10 +75,10 @@ def validate_token_ema_latency_SLA(response_detail, sla_token_gen, ema_span):
     return all([t < 1.0 / sla_token_gen for t in ema_latency])
 
 
-def validate_prompt_latency_SLA(response_detail, sla_token_gen, f):
+def validate_prompt_latency_SLA(response_detail, sla_token_gen, f, sla_prompt_tokens_per_sec ):
     tokenizer = get_tokenizer()
     prompt_length = len(tokenizer.tokenize(response_detail.prompt))
-    prompt_latency_SLA = prompt_length / SLA_PROMPT_TOKENS_PER_SEC
+    prompt_latency_SLA = prompt_length / sla_prompt_tokens_per_sec
     if prompt_latency_SLA < response_detail.token_gen_time[0]:
         return False
 
@@ -110,19 +94,19 @@ def calc_throughput(response_details):
     return len(response_details) / (end_time - start_time)
 
 
-def extract_values(file_pattern, sla_token_gen, validate_func):
+def extract_values(file_pattern, sla_token_gen, validate_func, sla_prompt_tokens_per_sec):
     files = glob.glob(file_pattern)
     print(f"Found {len(files)} files")
     goodputs = {}
     good_ratios = {}
     for f in files:
         prof_args, response_details = read_json(f)
-        client_num = prof_args["client_num"]
+        client_num = prof_args["num_clients"]
         num_req_ok = len(
             [
                 r
                 for r in response_details
-                if validate_prompt_latency_SLA(r, sla_token_gen, validate_func)
+                if validate_prompt_latency_SLA(r, sla_token_gen, validate_func, sla_prompt_tokens_per_sec)
             ]
         )
         goodputs[client_num] = calc_throughput(response_details) * (
@@ -133,7 +117,7 @@ def extract_values(file_pattern, sla_token_gen, validate_func):
     return goodputs, good_ratios
 
 
-def display_results(model_size, tp, bs, sla_token_gen, prompt, gen, log_dir, out_dir):
+def output_charts(model, tp_size, bs, replicas, sla_token_gen, prompt, gen, log_dir, out_dir):
     if not log_dir.exists():
         print(f"Log directory {log_dir} does not exist")
         return
@@ -142,47 +126,57 @@ def display_results(model_size, tp, bs, sla_token_gen, prompt, gen, log_dir, out
         out_dir.mkdir(parents=True, exist_ok=True)
 
     print(
-        f"model: {model_size} Prompt: {prompt}, Generation: {gen}, TP: {tp} sla_token_gen: {sla_token_gen}"
+        f"Model: {model} Prompt: {prompt}, Generation: {gen}, TP: {tp_size} sla_token_gen: {sla_token_gen}"
     )
 
-    mii_file_pattern = f"{log_dir}/logs.llama2-{model_size}-tp{tp}-b{bs}/llama2-{model_size}-tp{tp}-b{bs}_c*_p{prompt}_g{gen}.json"
-    if not args.no_vllm:
-        vllm_file_pattern = f"{log_dir}/logs.vllm-llama2-{model_size}-tp{tp}/vllm-llama2-{model_size}-tp{tp}_c*_p{prompt}_g{gen}.json"
+    result_file_pattern = f"{model}-tp{tp_size}-bs{bs}-replicas{replicas}-prompt{prompt}-gen{gen}-clients*.json"
 
     validate_funcs = [
         (validate_token_cum_latency_SLA, (), "cum"),
-        (validate_token_ema_latency_SLA, (EMA_SPAN,), f"ema{EMA_SPAN}"),
+        (validate_token_ema_latency_SLA, (args.ema_span,), f"ema{args.ema_span}"),
     ]
 
     for f in validate_funcs:
+        plt.figure(figsize=(7, 4))
 
-        mii_goodputs, mii_good_ratios = extract_values(
-            mii_file_pattern, sla_token_gen, f
-        )
-        client_num_list = sorted(list(mii_goodputs.keys()))
-        mii_goodputs_list = [mii_goodputs[client_num] for client_num in client_num_list]
-
-        if not args.no_vllm:
-            vllm_goodputs, vllm_good_ratios = extract_values(
-                vllm_file_pattern, sla_token_gen, f
+        if "fastgen" in args.backend:
+            mii_file_pattern = f"{log_dir}/fastgen/{result_file_pattern}"
+            mii_goodputs, mii_good_ratios = extract_values(
+                mii_file_pattern, sla_token_gen, f, args.sla_prompt_tokens_per_sec
             )
+            client_num_list = sorted(list(mii_goodputs.keys()))
+            mii_goodputs_list = [mii_goodputs[client_num] for client_num in client_num_list]
+
+            # Plotting the scatter plot
+            plt.scatter(
+                client_num_list,
+                mii_goodputs_list,
+                label=f"DeepSpeed-FastGen",
+                marker="o",
+                color="blue",
+            )
+
+            fit_x_list = np.arange(min(client_num_list), max(client_num_list), 0.1)
+            mii_fit_model = np.polyfit(client_num_list, mii_goodputs_list, 4)
+            mii_model_fn = np.poly1d(mii_fit_model)
+            plt.plot(
+                fit_x_list,
+                mii_model_fn(fit_x_list),
+                color="blue",
+                alpha=0.5,
+                linestyle="--",
+            )
+
+        if "vllm" in args.backend:
+            vllm_file_pattern = f"{log_dir}/vllm/{result_file_pattern}"
+            vllm_goodputs, vllm_good_ratios = extract_values(
+                vllm_file_pattern, sla_token_gen, f, args.sla_prompt_tokens_per_sec
+            )
+            client_num_list = sorted(list(vllm_goodputs.keys()))
             vllm_goodputs_list = [
                 vllm_goodputs[client_num] for client_num in client_num_list
             ]
 
-        # print(f"MII {mii_goodputs_list} ratio={mii_good_ratios}")
-        # print(f"vLLM {vllm_goodputs_list} ratio={vllm_good_ratios}")
-
-        # Plotting the scatter plot
-        plt.figure(figsize=(7, 4))
-        plt.scatter(
-            client_num_list,
-            mii_goodputs_list,
-            label=f"DeepSpeed-FastGen",
-            marker="o",
-            color="blue",
-        )
-        if not args.no_vllm:
             plt.scatter(
                 client_num_list,
                 vllm_goodputs_list,
@@ -191,18 +185,7 @@ def display_results(model_size, tp, bs, sla_token_gen, prompt, gen, log_dir, out
                 color="orange",
             )
 
-        fit_x_list = np.arange(min(client_num_list), max(client_num_list), 0.1)
-        mii_fit_model = np.polyfit(client_num_list, mii_goodputs_list, 4)
-        mii_model_fn = np.poly1d(mii_fit_model)
-        plt.plot(
-            fit_x_list,
-            mii_model_fn(fit_x_list),
-            color="blue",
-            alpha=0.5,
-            linestyle="--",
-        )
-
-        if not args.no_vllm:
+            fit_x_list = np.arange(min(client_num_list), max(client_num_list), 0.1)
             vllm_fit_model = np.polyfit(client_num_list, vllm_goodputs_list, 4)
             vllm_model_fn = np.poly1d(vllm_fit_model)
             plt.plot(
@@ -213,21 +196,23 @@ def display_results(model_size, tp, bs, sla_token_gen, prompt, gen, log_dir, out
                 linestyle="--",
             )
 
+        if "aml" in args.backend:
+            # TODO (lekurile): Add AML code here if/when streaming is supported
+            raise NotImplementedError("Effective throughput analysis is not supported for AML.")
+
         title = (
-            f"Effective throughput (SLA prompt: {SLA_PROMPT_TOKENS_PER_SEC} tokens/s, generation: {sla_token_gen} tokens/s)\n"
-            + f"Llama 2 {model_size.upper()} Prompt: {prompt}, Generation: {gen}, TP: {tp}"
+            f"Effective throughput (SLA prompt: {args.sla_prompt_tokens_per_sec} tokens/s, generation: {sla_token_gen} tokens/s)\n"
+            + f"Model: {model} Prompt: {prompt}, Generation: {gen}, TP: {tp_size}"
         )
         plt.title(title, fontsize=10)
         plt.xlabel("Number of clients", fontsize=10)
         plt.ylabel("Effective throughput (queries/s)", fontsize=10)
-        # plt.rcParams['figure.subplot.bottom'] = 0.30
         plt.ylim(bottom=-0.05)
         plt.legend()
         plt.grid(True)
-        # plt.show()
         out_file = (
             out_dir
-            / f"goodput_llama{model_size}_SLAp{SLA_PROMPT_TOKENS_PER_SEC}g{sla_token_gen}_tp{tp}_b{bs}_p{prompt}g{gen}_{f[2]}.png"
+            / f"{model}_SLAp{args.sla_prompt_tokens_per_sec}g{sla_token_gen}_tp{tp_size}_b{bs}_p{prompt}g{gen}_{f[2]}.png"
         )
         plt.savefig(out_file)
         plt.clf()
@@ -235,30 +220,20 @@ def display_results(model_size, tp, bs, sla_token_gen, prompt, gen, log_dir, out
 
 
 if __name__ == "__main__":
-    raise NotImplementedError("This script is not up to date")
     args = get_args()
 
-    # TODO: Generalize this
-    # TODO: carry over code from plot_th_lat.py
-    if args.test:
-        tp_sizes = tp_sizes_test
-        prompt_gen_pairs = prompt_gen_pairs_test
-    else:
-        tp_sizes = tp_sizes_all
-        prompt_gen_pairs = prompt_gen_pairs_all
+    result_params = get_result_sets(args)
 
-    for model_size, tps in tp_sizes.items():
-        for tp in tps:
-            for prompt, gen in prompt_gen_pairs:
-                for sla_token_gen in SLA_GEN_TOKENS_PER_SEC:
-                    # TODO: standardize names
-                    display_results(
-                        model_size,
-                        tp,
-                        RAGGED_BATCH_SIZE,
-                        sla_token_gen,
-                        prompt,
-                        gen,
-                        args.log_dir,
-                        args.out_dir,
-                    )
+    for model, tp_size, bs, replicas, prompt, gen in result_params:
+        for sla_token_gen in args.sla_gen_tokens_per_sec:
+             output_charts(
+                model=model,
+                tp_size=tp_size,
+                bs=bs,
+                replicas=replicas,
+                sla_token_gen=sla_token_gen,
+                prompt=prompt,
+                gen=gen,
+                log_dir=args.log_dir,
+                out_dir=args.out_dir,
+            )

--- a/benchmarks/inference/mii/src/plot_latency_percentile.py
+++ b/benchmarks/inference/mii/src/plot_latency_percentile.py
@@ -16,7 +16,7 @@ from postprocess_results import read_json, get_token_latency, get_result_sets
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
+    parser.add_argument("--backend", type=str, choices=["fastgen", "vllm"], default=["fastgen", "vllm"], \
                         nargs="+", help="Specify the backends to generate plots for")
     parser.add_argument("--log_dir", type=Path, default="./results")
     parser.add_argument(
@@ -70,10 +70,6 @@ def output_charts(args, model, tp_size, bs, replicas, prompt, gen, log_dir, out_
         mii_latencies = extract_values(args, mii_file_pattern)
         client_num_list = sorted(list(mii_latencies.keys()))
 
-    if "aml" in args.backend:
-        # TODO (lekurile): Add AML code here if/when streaming is supported
-        raise NotImplementedError("Percentile latency analysis is not supported for AML.")
-
     for client_num in client_num_list:
         plt.figure()
         percentile = 95
@@ -96,10 +92,6 @@ def output_charts(args, model, tp_size, bs, replicas, prompt, gen, log_dir, out_
                 x2, y2, width=0.3, label="DeepSpeed-FastGen", align="center", color="blue"
             )
 
-        if "aml" in args.backend:
-            # TODO (lekurile): Add AML code here if/when streaming is supported
-            raise NotImplementedError("Percentile latency analysis is not supported for AML.")
-
         out_file = (
             out_dir
             / f"p{percentile}_token_latency_{model}_c{client_num}_tp{tp_size}_p{prompt}g{gen}.png"
@@ -118,6 +110,8 @@ def output_charts(args, model, tp_size, bs, replicas, prompt, gen, log_dir, out_
 
 if __name__ == "__main__":
     args = get_args()
+
+    assert "aml" not in args.backend, "Percentile latency analysis is not supported for AML."
 
     result_params = get_result_sets(args)
 

--- a/benchmarks/inference/mii/src/plot_latency_percentile.py
+++ b/benchmarks/inference/mii/src/plot_latency_percentile.py
@@ -111,7 +111,7 @@ def output_charts(args, model, tp_size, bs, replicas, prompt, gen, log_dir, out_
         label_x = ["P50", "P90", "P95"]
         plt.xticks([1, 2.5, 4], label_x)
 
-        plt.title(f"Model {model}, Clients: {client_num}, Prompt: {prompt}, Gen: {gen}, TP: {tp_size}")
+        plt.title(f"Model: {model}, Clients: {client_num}, Prompt: {prompt}, Gen: {gen}, TP: {tp_size}")
         plt.savefig(out_file)
         print(f"Saved {out_file}")
 

--- a/benchmarks/inference/mii/src/plot_latency_percentile.py
+++ b/benchmarks/inference/mii/src/plot_latency_percentile.py
@@ -16,12 +16,12 @@ from postprocess_results import read_json, get_token_latency, get_result_sets
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--log_dir", type=Path, default=".")
+    parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
+                        nargs="+", help="Specify the backends to generate plots for")
+    parser.add_argument("--log_dir", type=Path, default="./results")
     parser.add_argument(
         "--out_dir", type=Path, default="./plots/percentile_token_latency"
     )
-    parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
-                        nargs="+", help="Specify the backends to generate plots for")
     parser.add_argument("--skip_head_token_num", type=int, default=1, help="Specify number of head tokens to skip")
     parser.add_argument("--skip_request_num", type=int, default=1, help="Specify number of requests to skip")
     args = parser.parse_args()

--- a/benchmarks/inference/mii/src/plot_latency_percentile.py
+++ b/benchmarks/inference/mii/src/plot_latency_percentile.py
@@ -121,7 +121,6 @@ if __name__ == "__main__":
 
     result_params = get_result_sets(args)
 
-    # Generate plots
     for model, tp_size, bs, replicas, prompt, gen in result_params:
         output_charts(
             args=args,

--- a/benchmarks/inference/mii/src/plot_latency_percentile.py
+++ b/benchmarks/inference/mii/src/plot_latency_percentile.py
@@ -64,12 +64,21 @@ def output_charts(args, model, tp_size, bs, replicas, prompt, gen, log_dir, out_
                'fastgen': {'bar_x': [1.3, 2.8, 4.3], 'label': 'DeepSpeed-FastGen', 'color': 'blue'}}
 
     latencies = {}
+    client_num_dict = {}
     for backend in args.backend:
         file_pattern = f"{log_dir}/{backend}/{result_file_pattern}"
         latencies[backend] = extract_values(args, file_pattern)
-        client_num_list = sorted(list(latencies[backend].keys()))
+        client_num_dict[backend] = set(sorted(list(latencies[backend].keys())))
 
-    for client_num in client_num_list:
+    # Intersection of clients across all backends
+    client_num_set = set()
+    for backend in args.backend:
+        if not client_num_set:
+            client_num_set = client_num_dict[backend]
+        else:
+            client_num_set = client_num_set.intersection(client_num_dict[backend])
+
+    for client_num in client_num_set:
         plt.figure()
         percentile = 95
 

--- a/benchmarks/inference/mii/src/plot_latency_percentile.py
+++ b/benchmarks/inference/mii/src/plot_latency_percentile.py
@@ -5,56 +5,52 @@
 
 import argparse
 import glob
+import re
+import os
 from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import itertools
 
-from .postprocess_results import read_json, get_token_latency
-
-bs = 768
-SKIP_HEAD_TOKEN_NUM = 2
-SKIP_REQUEST_NUM = 100
-
-tp_sizes = {
-    "70b": [4],
-}
-
-prompt_gen_pairs = [
-    (2600, 128),
-]
-
+from postprocess_results import read_json, get_token_latency, get_result_sets
 
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--log_dir", type=Path, default=".")
     parser.add_argument(
-        "--out_dir", type=Path, default="charts/percentile_token_latency"
+        "--out_dir", type=Path, default="./plots/percentile_token_latency"
     )
+    parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
+                        nargs="+", help="Specify the backends to generate plots for")
+    parser.add_argument("--skip_head_token_num", type=int, default=1, help="Specify number of head tokens to skip")
+    parser.add_argument("--skip_request_num", type=int, default=1, help="Specify number of requests to skip")
     args = parser.parse_args()
     return args
 
 
-def extract_values(file_pattern):
+def extract_values(args, file_pattern):
     files = glob.glob(file_pattern)
+
+    print(f"Found {len(files)}")
+    print("\n".join(files))
 
     latencies = {}
     for f in files:
         prof_args, response_details = read_json(f)
-        client_num = prof_args["client_num"]
+        client_num = prof_args["num_clients"]
 
         response_details.sort(key=lambda r: r.start_time)
-        response_details = response_details[SKIP_REQUEST_NUM:-SKIP_REQUEST_NUM]
-        token_latencies = [
-            r.token_gen_time[SKIP_HEAD_TOKEN_NUM:-1] for r in response_details
-        ]
 
+        response_details = response_details[args.skip_request_num:-args.skip_request_num]
+        token_latencies = [
+            r.token_gen_time[args.skip_head_token_num:-1] for r in response_details
+        ]
         flat_latency_list = list(itertools.chain(*token_latencies))
         latencies[client_num] = flat_latency_list
     return latencies
 
 
-def output_charts(model_size, tp, bs, prompt, gen, log_dir, out_dir):
+def output_charts(args, model, tp_size, bs, replicas, prompt, gen, log_dir, out_dir):
     if not log_dir.exists():
         print(f"Log directory {log_dir} does not exist")
         return
@@ -62,65 +58,79 @@ def output_charts(model_size, tp, bs, prompt, gen, log_dir, out_dir):
     if not out_dir.exists():
         out_dir.mkdir(parents=True, exist_ok=True)
 
-    mii_file_pattern = f"{log_dir}/logs.llama2-{model_size}-tp{tp}-b{bs}/llama2-{model_size}-tp{tp}-b{bs}_c*_p{prompt}_g{gen}.json"
-    vllm_file_pattern = f"{log_dir}/logs.vllm-llama2-{model_size}-tp{tp}/vllm-llama2-{model_size}-tp{tp}_c*_p{prompt}_g{gen}.json"
+    result_file_pattern = f"{model}-tp{tp_size}-bs{bs}-replicas{replicas}-prompt{prompt}-gen{gen}-clients*.json"
 
-    mii_latencies = extract_values(mii_file_pattern)
-    vllm_latencies = extract_values(vllm_file_pattern)
-    client_num_list = sorted(list(mii_latencies.keys()))
+    if "vllm" in args.backend:
+        vllm_file_pattern = f"{log_dir}/vllm/{result_file_pattern}"
+        vllm_latencies = extract_values(args, vllm_file_pattern)
+        client_num_list = sorted(list(vllm_latencies.keys()))
+
+    if "fastgen" in args.backend:
+        mii_file_pattern = f"{log_dir}/fastgen/{result_file_pattern}"
+        mii_latencies = extract_values(args, mii_file_pattern)
+        client_num_list = sorted(list(mii_latencies.keys()))
+
+    if "aml" in args.backend:
+        # TODO (lekurile): Add AML code here if/when streaming is supported
+        raise NotImplementedError("Percentile latency analysis is not supported for AML.")
 
     for client_num in client_num_list:
-        plt.figure(figsize=(6, 4))
-
+        plt.figure()
         percentile = 95
 
-        P50_vllm_val = np.percentile(vllm_latencies[client_num], 50)
-        P50_mii_val = np.percentile(mii_latencies[client_num], 50)
-        P90_vllm_val = np.percentile(vllm_latencies[client_num], 90)
-        P90_mii_val = np.percentile(mii_latencies[client_num], 90)
-        P95_vllm_val = np.percentile(vllm_latencies[client_num], 95)
-        P95_mii_val = np.percentile(mii_latencies[client_num], 95)
+        if "vllm" in args.backend:
+            P50_vllm_val = np.percentile(vllm_latencies[client_num], 50)
+            P90_vllm_val = np.percentile(vllm_latencies[client_num], 90)
+            P95_vllm_val = np.percentile(vllm_latencies[client_num], 95)
+            x1 = [1, 2.5, 4]
+            y1 = [P50_vllm_val, P90_vllm_val, P95_vllm_val]
+            plt.bar(x1, y1, width=0.3, label="vLLM", align="center", color="orange")
 
-        # print(f"P50_vllm_val={P50_vllm_val}")
-        # print(f"P50_mii_val={P50_mii_val}")
-        # print(f"P90_vllm_val={P90_vllm_val}")
-        # print(f"P90_mii_val={P90_mii_val}")
-        # print(f"P95_vllm_val={P95_vllm_val}")
-        # print(f"P95_mii_val={P95_mii_val}")
+        if "fastgen" in args.backend:
+            P50_mii_val = np.percentile(mii_latencies[client_num], 50)
+            P90_mii_val = np.percentile(mii_latencies[client_num], 90)
+            P95_mii_val = np.percentile(mii_latencies[client_num], 95)
+            x2 = [1.3, 2.8, 4.3]
+            y2 = [P50_mii_val, P90_mii_val, P95_mii_val]
+            plt.bar(
+                x2, y2, width=0.3, label="DeepSpeed-FastGen", align="center", color="blue"
+            )
+
+        if "aml" in args.backend:
+            # TODO (lekurile): Add AML code here if/when streaming is supported
+            raise NotImplementedError("Percentile latency analysis is not supported for AML.")
 
         out_file = (
             out_dir
-            / f"p{percentile}_token_latency_llama{model_size}_c{client_num}_tp{tp}_p{prompt}g{gen}.png"
+            / f"p{percentile}_token_latency_{model}_c{client_num}_tp{tp_size}_p{prompt}g{gen}.png"
         )
 
-        x1 = [1, 2, 3]
-        y1 = [P50_vllm_val, P90_vllm_val, P95_vllm_val]
-
-        x2 = [1.3, 2.3, 3.3]
-        y2 = [P50_mii_val, P90_mii_val, P95_mii_val]
-
-        label_x = ["P50", "P90", "P95"]
-
-        plt.bar(x1, y1, width=0.3, label="vLLM", align="center", color="orange")
-        plt.bar(
-            x2, y2, width=0.3, label="DeepSpeed-FastGen", align="center", color="blue"
-        )
-        plt.ylabel("Latency", fontsize=14)
+        plt.ylabel("Latency (s)", fontsize=14)
         plt.legend(loc=2)
 
-        plt.xticks([1.15, 2.15, 3.15], label_x)
+        label_x = ["P50", "P90", "P95"]
+        plt.xticks([1, 2.5, 4], label_x)
 
+        plt.title(f"Model {model}, Clients: {client_num}, Prompt: {prompt}, Gen: {gen}, TP: {tp_size}")
         plt.savefig(out_file)
         print(f"Saved {out_file}")
 
 
 if __name__ == "__main__":
-    raise NotImplementedError("This script is not up to date")
     args = get_args()
 
-    for model_size, tps in tp_sizes.items():
-        for tp in tps:
-            for prompt, gen in prompt_gen_pairs:
-                output_charts(
-                    model_size, tp, bs, prompt, gen, args.log_dir, args.out_dir
-                )
+    result_params = get_result_sets(args)
+
+    # Generate plots
+    for model, tp_size, bs, replicas, prompt, gen in result_params:
+        output_charts(
+            args=args,
+            model=model,
+            tp_size=tp_size,
+            bs=bs,
+            replicas=replicas,
+            prompt=prompt,
+            gen=gen,
+            log_dir=args.log_dir,
+            out_dir=args.out_dir,
+        )

--- a/benchmarks/inference/mii/src/plot_repl_scale.py
+++ b/benchmarks/inference/mii/src/plot_repl_scale.py
@@ -13,8 +13,8 @@ from postprocess_results import read_json, get_summary, get_result_sets
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
-                        nargs="+", help="Specify the backends to generate plots for")
+    parser.add_argument("--backend", type=str, choices=["fastgen"], default=["fastgen"], \
+                        nargs=1, help="Specify the single backend to generate plots for")
     parser.add_argument("--clients_per_replica", type=int, required=False, default=None, help="Optional \
                         argument to specify explicit clients/replica to generate plot for")
     parser.add_argument("--log_dir", type=Path, default="./results")
@@ -84,7 +84,7 @@ def output_charts(args, model, tp_size, bs, replica_nums, prompt, gen, log_dir, 
             plt.ylabel("Throughput (queries/s)", fontsize=14)
             plt.grid(True)
             plt.tight_layout()
-            out_file = out_dir / f"repl_scale_{model}_tp{tp_size}_p{prompt}g{gen}_c{c}.png"
+            out_file = out_dir / f"repl_scale_{model}_tp{tp_size}_p{prompt}g{gen}_c_per_r{c}.png"
             plt.savefig(out_file)
 
 

--- a/benchmarks/inference/mii/src/plot_repl_scale.py
+++ b/benchmarks/inference/mii/src/plot_repl_scale.py
@@ -9,25 +9,16 @@ import argparse
 from pathlib import Path
 import numpy as np
 
-from .postprocess_results import read_json, get_summary
-
-bs = 768
-
-REPLICA_NUMS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
-
-tp_sizes = {
-    "70b": [4],
-}
-
-prompt_gen_pairs = [
-    (2600, 60),
-]
-
+from postprocess_results import read_json, get_summary, get_result_sets
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--log_dir", type=Path, default=".")
-    parser.add_argument("--out_dir", type=Path, default="charts/repl_scale")
+    parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
+                        nargs="+", help="Specify the backends to generate plots for")
+    parser.add_argument("--clients_per_replica", type=int, required=False, default=None, help="Optional \
+                        argument to specify explicit clients/replica to generate plot for")
+    parser.add_argument("--log_dir", type=Path, default="./results")
+    parser.add_argument("--out_dir", type=Path, default="./plots/repl_scale")
     args = parser.parse_args()
     return args
 
@@ -41,14 +32,14 @@ def extract_values(file_pattern):
     for f in files:
         prof_args, response_details = read_json(f)
         summary = get_summary(prof_args, response_details)
-        clients.append(prof_args["client_num"])
+        clients.append(prof_args["num_clients"])
         throughputs.append(summary.throughput)
         latencies.append(summary.latency)
 
     return clients, throughputs, latencies
 
 
-def output_charts(model_size, tp, bs, prompt, gen, log_dir, out_dir):
+def output_charts(args, model, tp_size, bs, replica_nums, prompt, gen, log_dir, out_dir):
     if not log_dir.exists():
         print(f"Log directory {log_dir} does not exist")
         return
@@ -57,8 +48,9 @@ def output_charts(model_size, tp, bs, prompt, gen, log_dir, out_dir):
         out_dir.mkdir(parents=True, exist_ok=True)
 
     throughputs = {}
-    for repl in REPLICA_NUMS:
-        mii_file_pattern = f"{log_dir}/logs.llama2-{model_size}-tp{tp}-b{bs}_repl{repl}/llama2-{model_size}-tp{tp}-b{bs}_repl{repl}_c*_p{prompt}_g{gen}.json"
+    for repl in replica_nums:
+        result_file_pattern = f"{model}-tp{tp_size}-bs{bs}-replicas{repl}-prompt{prompt}-gen{gen}-clients*.json"
+        mii_file_pattern = f"{log_dir}/fastgen/{result_file_pattern}"
         print(f"Looking for {mii_file_pattern}")
         clients, mii_throughputs, mii_latencies = extract_values(mii_file_pattern)
 
@@ -70,36 +62,59 @@ def output_charts(model_size, tp, bs, prompt, gen, log_dir, out_dir):
             throughputs[client_per_repl].append(th)
 
     for c in throughputs:
+        if args.clients_per_replica != None and args.clients_per_replica != c:
+            continue
+        if len(throughputs[c]) == len(replica_nums):
+            print(f"Generating figure for {c} clients/replica.")
+            # Plotting the scatter plot
+            plt.figure()
 
-        # Plotting the scatter plot
-        plt.figure(figsize=(6, 4))
+            plt.bar(replica_nums, throughputs[c], color="blue", alpha=0.9)
 
-        plt.bar(REPLICA_NUMS, throughputs[c], color="blue", alpha=0.9)
+            fit_x_list = np.arange(min(replica_nums), max(replica_nums), 0.1)
+            mii_fit_model = np.polyfit(replica_nums, throughputs[c], 1)
+            mii_model_fn = np.poly1d(mii_fit_model)
+            plt.plot(fit_x_list, mii_model_fn(fit_x_list), color="blue", linestyle="--")
 
-        fit_x_list = np.arange(min(REPLICA_NUMS), max(REPLICA_NUMS), 0.1)
-        mii_fit_model = np.polyfit(REPLICA_NUMS, throughputs[c], 1)
-        mii_model_fn = np.poly1d(mii_fit_model)
-        plt.plot(fit_x_list, mii_model_fn(fit_x_list), color="blue", linestyle="--")
-
-        plt.title(
-            f"Model Llama 2 {model_size.upper()}, Prompt: {prompt}, Generation: {gen}, TP: {tp}"
-        )
-        plt.xlabel("Number of replicas", fontsize=14)
-        plt.ylabel("Throughput (queries/s)", fontsize=14)
-        plt.grid(True)
-        plt.tight_layout()
-        # plt.show()
-        out_file = out_dir / f"repl_scale_llama{model_size}_tp{tp}_p{prompt}g{gen}.png"
-        plt.savefig(out_file)
+            plt.title(
+                f"Model: {model}, Prompt: {prompt}, Generation: {gen}\n\
+                TP: {tp_size}, Clients/Replica: {c}"
+            )
+            plt.xlabel("Number of replicas", fontsize=14)
+            plt.ylabel("Throughput (queries/s)", fontsize=14)
+            plt.grid(True)
+            plt.tight_layout()
+            out_file = out_dir / f"repl_scale_{model}_tp{tp_size}_p{prompt}g{gen}_c{c}.png"
+            plt.savefig(out_file)
 
 
 if __name__ == "__main__":
-    raise NotImplementedError("This script is not up to date")
     args = get_args()
 
-    for model_size, tps in tp_sizes.items():
-        for tp in tps:
-            for prompt, gen in prompt_gen_pairs:
-                output_charts(
-                    model_size, tp, bs, prompt, gen, args.log_dir, args.out_dir
-                )
+    replica_sets = {}
+
+    result_params = get_result_sets(args)
+
+    # Find all replicas across same sets
+    for model, tp_size, bs, replicas, prompt, gen in result_params:
+        key = f'{model}_{tp_size}_{bs}_{prompt}_{gen}'
+        set_dict = replica_sets.setdefault(f'{model}_{tp_size}_{bs}_{prompt}_{gen}', dict())
+        set_dict.setdefault(f'config', set()).add((model, tp_size, bs, prompt, gen))
+        replicas_list = set_dict.setdefault(f'replicas', list())
+        if replicas not in replicas_list:
+            replicas_list.append(int(replicas))
+
+    for replica_set in replica_sets.values():
+        for model, tp_size, bs, prompt, gen in replica_set['config']:
+            replica_nums = sorted(list(replica_set['replicas']))
+            output_charts(
+                args=args,
+                model=model,
+                tp_size=tp_size,
+                bs=bs,
+                replica_nums=replica_nums,
+                prompt=prompt,
+                gen=gen,
+                log_dir=args.log_dir,
+                out_dir=args.out_dir,
+            )

--- a/benchmarks/inference/mii/src/plot_th_lat.py
+++ b/benchmarks/inference/mii/src/plot_th_lat.py
@@ -17,10 +17,10 @@ from postprocess_results import read_json, get_summary, get_result_sets
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--log_dir", type=Path, default="./results")
-    parser.add_argument("--out_dir", type=Path, default="./plots/throughput_latency")
     parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
                         nargs="+", help="Specify the backends to generate plots for")
+    parser.add_argument("--log_dir", type=Path, default="./results")
+    parser.add_argument("--out_dir", type=Path, default="./plots/throughput_latency")
     args = parser.parse_args()
     return args
 

--- a/benchmarks/inference/mii/src/plot_th_lat.py
+++ b/benchmarks/inference/mii/src/plot_th_lat.py
@@ -121,7 +121,7 @@ def output_charts(model, tp_size, bs, replicas, prompt, gen, log_dir, out_dir):
         )
 
     # Generic plot formatting
-    plt.title(f"Model {model}, Prompt: {prompt}, Generation: {gen}, TP: {tp_size}")
+    plt.title(f"Model: {model}, Prompt: {prompt}, Generation: {gen}, TP: {tp_size}")
     plt.xlabel("Throughput (queries/s)", fontsize=14)
     plt.ylabel("Latency (s)", fontsize=14)
     plt.legend()

--- a/benchmarks/inference/mii/src/plot_th_lat.py
+++ b/benchmarks/inference/mii/src/plot_th_lat.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 
-from postprocess_results import read_json, get_summary
+from postprocess_results import read_json, get_summary, get_result_sets
 
 
 def get_args():
@@ -105,7 +105,7 @@ def output_charts(model, tp_size, bs, replicas, prompt, gen, log_dir, out_dir):
         plt.scatter(
             aml_throughputs,
             aml_latencies,
-            label=f"AML {aml_endpoint_name.capitalize()}:{aml_deployment_name}",
+            label=f"AML {aml_endpoint_name.capitalize()}",
             marker="o",
             color="purple",
         )
@@ -141,15 +141,7 @@ if __name__ == "__main__":
     if not args.log_dir.exists():
         raise ValueError(f"Log dir {args.log_dir} does not exist")
 
-    result_params = set()
-    result_re = re.compile(
-        r"(.+)-tp(\d+)-bs(\d+)-replicas(\d+)-prompt(\d+)-gen(\d+)-clients.*.json"
-    )
-
-    for f in os.listdir(os.path.join(args.log_dir, args.backend[1])):
-        match = result_re.match(f)
-        if match:
-            result_params.add(match.groups())
+    result_params = get_result_sets(args)
 
     for model, tp_size, bs, replicas, prompt, gen in result_params:
         output_charts(

--- a/benchmarks/inference/mii/src/plot_th_lat.py
+++ b/benchmarks/inference/mii/src/plot_th_lat.py
@@ -19,6 +19,8 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--log_dir", type=Path, default="./results")
     parser.add_argument("--out_dir", type=Path, default="./plots/throughput_latency")
+    parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
+                        nargs="+", help="Specify the backends to generate plots for")
     args = parser.parse_args()
     return args
 
@@ -32,6 +34,7 @@ def extract_values(file_pattern):
     clients = []
     throughputs = []
     latencies = []
+    extra_args = {}
     for f in files:
         prof_args, response_details = read_json(f)
         summary = get_summary(prof_args, response_details)
@@ -39,58 +42,88 @@ def extract_values(file_pattern):
         throughputs.append(summary.throughput)
         latencies.append(summary.latency)
 
-    return clients, throughputs, latencies
+        if "aml" in args.backend:
+            extra_args["aml_api_url"] = prof_args["aml_api_url"]
+            extra_args["deployment_name"] = prof_args["deployment_name"]
+
+    return clients, throughputs, latencies, extra_args
 
 
 def output_charts(model, tp_size, bs, replicas, prompt, gen, log_dir, out_dir):
     out_dir.mkdir(parents=True, exist_ok=True)
 
     result_file_pattern = f"{model}-tp{tp_size}-bs{bs}-replicas{replicas}-prompt{prompt}-gen{gen}-clients*.json"
-    mii_file_pattern = f"{log_dir}/fastgen/{result_file_pattern}"
-    vllm_file_pattern = f"{log_dir}/vllm/{result_file_pattern}"
-
-    _, mii_throughputs, mii_latencies = extract_values(mii_file_pattern)
-    _, vllm_throughputs, vllm_latencies = extract_values(vllm_file_pattern)
 
     # Plotting the scatter plot
-    plt.figure(figsize=(6, 4))
+    # vLLM plot formatting
+    if "vllm" in args.backend:
+        vllm_file_pattern = f"{log_dir}/vllm/{result_file_pattern}"
+        _, vllm_throughputs, vllm_latencies, _ = extract_values(vllm_file_pattern)
+        if len(vllm_throughputs) > 0:
+            plt.scatter(
+                vllm_throughputs, vllm_latencies, label=f"vLLM", marker="x", color="orange"
+            )
+            fit_vllm_x_list = np.arange(min(vllm_throughputs), max(vllm_throughputs), 0.01)
+            vllm_vllm_model = np.polyfit(vllm_throughputs, vllm_latencies, 3)
+            vllm_model_fn = np.poly1d(vllm_vllm_model)
+            plt.plot(
+                fit_vllm_x_list,
+                vllm_model_fn(fit_vllm_x_list),
+                color="orange",
+                alpha=0.5,
+                linestyle="--",
+            )
 
-    if len(vllm_throughputs) > 0:
+    # FastGen plot formatting
+    if "fastgen" in args.backend:
+        mii_file_pattern = f"{log_dir}/fastgen/{result_file_pattern}"
+        _, mii_throughputs, mii_latencies, _ = extract_values(mii_file_pattern)
         plt.scatter(
-            vllm_throughputs, vllm_latencies, label=f"vLLM", marker="x", color="orange"
+            mii_throughputs,
+            mii_latencies,
+            label=f"DeepSpeed FastGen",
+            marker="o",
+            color="blue",
         )
-        fit_vllm_x_list = np.arange(min(vllm_throughputs), max(vllm_throughputs), 0.01)
-        vllm_vllm_model = np.polyfit(vllm_throughputs, vllm_latencies, 3)
-        vllm_model_fn = np.poly1d(vllm_vllm_model)
+        fit_mii_x_list = np.arange(min(mii_throughputs), max(mii_throughputs), 0.01)
+        mii_fit_model = np.polyfit(mii_throughputs, mii_latencies, 3)
+        mii_model_fn = np.poly1d(mii_fit_model)
         plt.plot(
-            fit_vllm_x_list,
-            vllm_model_fn(fit_vllm_x_list),
-            color="orange",
+            fit_mii_x_list,
+            mii_model_fn(fit_mii_x_list),
+            color="blue",
             alpha=0.5,
             linestyle="--",
         )
 
-    plt.scatter(
-        mii_throughputs,
-        mii_latencies,
-        label=f"DeepSpeed FastGen",
-        marker="o",
-        color="blue",
-    )
-    fit_mii_x_list = np.arange(min(mii_throughputs), max(mii_throughputs), 0.01)
-    mii_fit_model = np.polyfit(mii_throughputs, mii_latencies, 3)
-    mii_model_fn = np.poly1d(mii_fit_model)
-    plt.plot(
-        fit_mii_x_list,
-        mii_model_fn(fit_mii_x_list),
-        color="blue",
-        alpha=0.5,
-        linestyle="--",
-    )
+    # AML plot formatting
+    if "aml" in args.backend:
+        aml_file_pattern = f"{log_dir}/aml/{result_file_pattern}"
+        _, aml_throughputs, aml_latencies, aml_args = extract_values(aml_file_pattern)
+        aml_endpoint_name = re.match('^https://(.+?)\.', aml_args["aml_api_url"]).groups()[0]
+        aml_deployment_name = aml_args["deployment_name"]
+        plt.scatter(
+            aml_throughputs,
+            aml_latencies,
+            label=f"AML {aml_endpoint_name.capitalize()}:{aml_deployment_name}",
+            marker="o",
+            color="purple",
+        )
+        fit_aml_x_list = np.arange(min(aml_throughputs), max(aml_throughputs), 0.01)
+        aml_fit_model = np.polyfit(aml_throughputs, aml_latencies, 3)
+        aml_model_fn = np.poly1d(aml_fit_model)
+        plt.plot(
+            fit_aml_x_list,
+            aml_model_fn(fit_aml_x_list),
+            color="purple",
+            alpha=0.5,
+            linestyle="--",
+        )
 
+    # Generic plot formatting
     plt.title(f"Model {model}, Prompt: {prompt}, Generation: {gen}, TP: {tp_size}")
     plt.xlabel("Throughput (queries/s)", fontsize=14)
-    plt.ylabel("Latency", fontsize=14)
+    plt.ylabel("Latency (s)", fontsize=14)
     plt.legend()
     plt.grid(True)
     plt.tight_layout()
@@ -112,7 +145,8 @@ if __name__ == "__main__":
     result_re = re.compile(
         r"(.+)-tp(\d+)-bs(\d+)-replicas(\d+)-prompt(\d+)-gen(\d+)-clients.*.json"
     )
-    for f in os.listdir(os.path.join(args.log_dir, "fastgen")):
+
+    for f in os.listdir(os.path.join(args.log_dir, args.backend[1])):
         match = result_re.match(f)
         if match:
             result_params.add(match.groups())

--- a/benchmarks/inference/mii/src/plot_th_lat.py
+++ b/benchmarks/inference/mii/src/plot_th_lat.py
@@ -54,6 +54,8 @@ def output_charts(model, tp_size, bs, replicas, prompt, gen, log_dir, out_dir):
 
     result_file_pattern = f"{model}-tp{tp_size}-bs{bs}-replicas{replicas}-prompt{prompt}-gen{gen}-clients*.json"
 
+    plt.figure()
+
     # Plotting the scatter plot
     # vLLM plot formatting
     if "vllm" in args.backend:

--- a/benchmarks/inference/mii/src/plot_tp_sizes.py
+++ b/benchmarks/inference/mii/src/plot_tp_sizes.py
@@ -8,13 +8,16 @@ import matplotlib.pyplot as plt
 import argparse
 from pathlib import Path
 import numpy as np
+import re
 
-from .postprocess_results import read_json, get_summary
+from postprocess_results import read_json, get_summary, get_result_sets
 
 def get_args():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
+                        nargs=1, help="Specify the single backend to generate plots for")
     parser.add_argument("--log_dir", type=Path, default="logs.release")
-    parser.add_argument("--out_dir", type=Path, default="charts/tp_sizes")
+    parser.add_argument("--out_dir", type=Path, default="./plots/tp_sizes")
     args = parser.parse_args()
     return args
 
@@ -31,14 +34,14 @@ def extract_values(file_pattern):
     for f in files:
         prof_args, response_details = read_json(f)
         summary = get_summary(prof_args, response_details)
-        clients.append(prof_args["client_num"])
+        clients.append(prof_args["num_clients"])
         throughputs.append(summary.throughput)
         latencies.append(summary.latency)
 
     return clients, throughputs, latencies
 
 
-def output_charts(model_size, tps, bs, prompt, gen, log_dir, out_dir):
+def output_charts(args, model, tp_list, bs, replicas, prompt, gen, log_dir, out_dir):
     if not log_dir.exists():
         print(f"Log directory {log_dir} does not exist")
         return
@@ -47,23 +50,24 @@ def output_charts(model_size, tps, bs, prompt, gen, log_dir, out_dir):
         out_dir.mkdir(parents=True, exist_ok=True)
 
     # Plotting the scatter plot
-    plt.figure(figsize=(6, 4))
+    plt.figure()
 
-    colors = ["orange", "green", "brown"]
-
-    for tp, color in zip(tps, colors):
-        mii_file_pattern = f"{log_dir}/logs.llama2-{model_size}-tp{tp}-b{bs}/llama2-{model_size}-tp{tp}-b{bs}_c*_p{prompt}_g{gen}.json"
+    for tp in tp_list:
+        result_file_pattern = f"{model}-tp{tp}-bs{bs}-replicas{replicas}-prompt{prompt}-gen{gen}-clients*.json"
+        mii_file_pattern = f"{log_dir}/{args.backend[0]}/{result_file_pattern}"
         _, mii_throughputs, mii_latencies = extract_values(mii_file_pattern)
 
         if len(mii_throughputs) == 0:
             continue
 
+        # TODO (lekurile): model_size assumes size is in billions, generalize (holdover)
+        model_size = re.match('.*?(\d+[b|B])', model).groups()[0]
         n_params = int(model_size[:-1])
-        tflops_per_query = n_params * (prompt + gen) * 2 * 1e-3
+        tflops_per_query = n_params * (int(prompt) + int(gen)) * 2 * 1e-3
         mii_tflops = [th * tflops_per_query / tp for th in mii_throughputs]
 
         plt.scatter(
-            mii_tflops, mii_latencies, label=f"TP={tp}", marker="o", color=color
+            mii_tflops, mii_latencies, label=f"TP={tp}", marker="o"
         )
         fit_mii_x_list = np.arange(min(mii_tflops), max(mii_tflops), 0.01)
         mii_fit_model = np.polyfit(mii_tflops, mii_latencies, 3)
@@ -71,48 +75,52 @@ def output_charts(model_size, tps, bs, prompt, gen, log_dir, out_dir):
         plt.plot(
             fit_mii_x_list,
             mii_model_fn(fit_mii_x_list),
-            color=color,
             alpha=0.5,
             linestyle="--",
         )
 
     plt.title(
-        f"Model Llama 2 {model_size.upper()}, Prompt: {prompt}, Generation: {gen}, TP: {tps}"
+        f"Model: {model}, Prompt: {prompt}, Generation: {gen}, TP: {tp_list}\n\
+        Replicas: {replicas}, Backend: {args.backend[0]}"
     )
     plt.xlabel("TFLOPs (per GPU)", fontsize=14)
-    plt.ylabel("Latency", fontsize=14)
+    plt.ylabel("Latency (s)", fontsize=14)
     plt.legend()
     plt.grid(True)
-    # plt.show()
     out_file = (
         out_dir
-        / f"tp_sizes_llama{model_size}_tp{'_'.join([str(tp) for tp in tps])}_p{prompt}g{gen}.png"
+        / f"tp_sizes_{model}_tp{'_'.join([str(tp) for tp in tp_list])}_p{prompt}g{gen}r{replicas}.png"
     )
     plt.savefig(out_file)
 
 
 if __name__ == "__main__":
-    #raise NotImplementedError("This script is not up to date")
     args = get_args()
 
+    tp_sets = {}
 
-    #bs = 768
-    #
-    #tp_sizes = {
-    #    # "7b": [1],
-    #    "13b": [1, 2, 4],
-    #    # "70b": [4, 8],
-    #}
-    #
-    #prompt_gen_pairs = [
-    #    (1200, 60),
-    #    (1200, 128),
-    #    (2600, 60),
-    #    (2600, 128),
-    #    (2600, 256),
-    #]
+    result_params = get_result_sets(args)
 
+    # Find all tp_sizes across same sets
+    for model, tp_size, bs, replicas, prompt, gen in result_params:
+        key = f'{model}_{bs}_{replicas}_{prompt}_{gen}'
+        set_dict = tp_sets.setdefault(f'{model}_{bs}_{replicas}_{prompt}_{gen}', dict())
+        set_dict.setdefault(f'config', set()).add((model, bs, replicas, prompt, gen))
+        tp_list = set_dict.setdefault(f'tp_list', list())
+        if tp_size not in tp_list:
+            tp_list.append(int(tp_size))
 
-    for model_size, tps in tp_sizes.items():
-        for prompt, gen in prompt_gen_pairs:
-            output_charts(model_size, tps, bs, prompt, gen, args.log_dir, args.out_dir)
+    for tp_set in tp_sets.values():
+        for model, bs, replicas, prompt, gen in tp_set['config']:
+            tp_list = sorted(list(tp_set['tp_list']))
+            output_charts(
+                args=args,
+                model=model,
+                tp_list=tp_list,
+                bs=bs,
+                replicas=replicas,
+                prompt=prompt,
+                gen=gen,
+                log_dir=args.log_dir,
+                out_dir=args.out_dir,
+            )

--- a/benchmarks/inference/mii/src/plot_tp_sizes.py
+++ b/benchmarks/inference/mii/src/plot_tp_sizes.py
@@ -61,9 +61,11 @@ def output_charts(args, model, tp_list, bs, replicas, prompt, gen, log_dir, out_
         if len(mii_throughputs) == 0:
             continue
 
-        # TODO (lekurile): model_size assumes size is in billions, generalize (holdover)
-        model_size = re.match('.*?(\d+[b|B])', model).groups()[0]
+        model_size = re.match('.*?(\d+[b|B|m|M])', model).groups()[0]
         n_params = int(model_size[:-1])
+        if model_size[-1].lower() == 'm':
+            # Scale n_params approriately for millions
+            n_params = n_params / 1000
         tflops_per_query = n_params * (int(prompt) + int(gen)) * 2 * 1e-3
         mii_tflops = [th * tflops_per_query / tp for th in mii_throughputs]
 

--- a/benchmarks/inference/mii/src/plot_tp_sizes.py
+++ b/benchmarks/inference/mii/src/plot_tp_sizes.py
@@ -11,23 +11,6 @@ import numpy as np
 
 from .postprocess_results import read_json, get_summary
 
-bs = 768
-
-tp_sizes = {
-    # "7b": [1],
-    "13b": [1, 2, 4],
-    # "70b": [4, 8],
-}
-
-prompt_gen_pairs = [
-    (1200, 60),
-    (1200, 128),
-    (2600, 60),
-    (2600, 128),
-    (2600, 256),
-]
-
-
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--log_dir", type=Path, default="logs.release")
@@ -109,8 +92,26 @@ def output_charts(model_size, tps, bs, prompt, gen, log_dir, out_dir):
 
 
 if __name__ == "__main__":
-    raise NotImplementedError("This script is not up to date")
+    #raise NotImplementedError("This script is not up to date")
     args = get_args()
+
+
+    #bs = 768
+    #
+    #tp_sizes = {
+    #    # "7b": [1],
+    #    "13b": [1, 2, 4],
+    #    # "70b": [4, 8],
+    #}
+    #
+    #prompt_gen_pairs = [
+    #    (1200, 60),
+    #    (1200, 128),
+    #    (2600, 60),
+    #    (2600, 128),
+    #    (2600, 256),
+    #]
+
 
     for model_size, tps in tp_sizes.items():
         for prompt, gen in prompt_gen_pairs:

--- a/benchmarks/inference/mii/src/postprocess_results.py
+++ b/benchmarks/inference/mii/src/postprocess_results.py
@@ -176,7 +176,7 @@ def get_result_sets(args: argparse.Namespace) -> set():
     # Warning messages about skipped sets
     for key, backend_set in backend_sets.items():
         difference = backend_set.difference(result_params)
-        if bool(difference):
+        if difference:
             print(f"WARNING: backend {key} has result combinations that are not present in all backends:")
             print(tabulate(difference, headers=["model", "tp_size", "bs", "replicas", "prompt", "gen"]))
 

--- a/benchmarks/inference/mii/src/postprocess_results.py
+++ b/benchmarks/inference/mii/src/postprocess_results.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import re
 import os
+from tabulate import tabulate
 from dataclasses import dataclass
 from functools import reduce
 from pathlib import Path
@@ -176,6 +177,7 @@ def get_result_sets(args: argparse.Namespace) -> set():
     for key, backend_set in backend_sets.items():
         difference = backend_set.difference(result_params)
         if bool(difference):
-            print(f"WARNING: backend {key} has result combinations that are not present in all backends:\n{difference}")
+            print(f"WARNING: backend {key} has result combinations that are not present in all backends:")
+            print(tabulate(difference, headers=["model", "tp_size", "bs", "replicas", "prompt", "gen"]))
 
     return result_params

--- a/benchmarks/inference/mii/src/postprocess_results.py
+++ b/benchmarks/inference/mii/src/postprocess_results.py
@@ -179,5 +179,6 @@ def get_result_sets(args: argparse.Namespace) -> set():
         if difference:
             print(f"WARNING: backend {key} has result combinations that are not present in all backends:")
             print(tabulate(difference, headers=["model", "tp_size", "bs", "replicas", "prompt", "gen"]))
+            print("")
 
     return result_params

--- a/benchmarks/inference/mii/src/postprocess_results.py
+++ b/benchmarks/inference/mii/src/postprocess_results.py
@@ -13,6 +13,7 @@ from functools import reduce
 from pathlib import Path
 from statistics import mean
 from typing import List
+from collections import defaultdict
 
 import numpy as np
 from transformers import AutoTokenizer
@@ -157,14 +158,14 @@ def get_result_sets(args: argparse.Namespace) -> set():
         r"(.+)-tp(\d+)-bs(\d+)-replicas(\d+)-prompt(\d+)-gen(\d+)-clients.*.json"
     )
 
-    backend_sets = {}
+    backend_sets = defaultdict(set)
 
     # Generate backend sets
     for backend in args.backend:
         for f in os.listdir(os.path.join(args.log_dir, backend)):
             match = result_re.match(f)
             if match:
-                backend_sets.setdefault(f'{backend}', set()).add(match.groups())
+                backend_sets[backend].add(match.groups())
 
     # Intersection between all sets
     for backend_set in backend_sets.values():

--- a/benchmarks/inference/mii/src/server.py
+++ b/benchmarks/inference/mii/src/server.py
@@ -49,11 +49,11 @@ def start_vllm_server(args: argparse.Namespace) -> None:
             break
         if "error" in line.lower():
             p.terminate()
-            stop_vllm_server()
+            stop_vllm_server(args)
             raise RuntimeError(f"Error starting VLLM server: {line}")
         if time.time() - start_time > timeout_after:
             p.terminate()
-            stop_vllm_server()
+            stop_vllm_server(args)
             raise TimeoutError("Timed out waiting for VLLM server to start")
         time.sleep(0.01)
 


### PR DESCRIPTION
This PR fixes/updates the inference benchmarking analysis scripts to support `[fastgen, vllm, aml]` backends. The scripts are generalized to support models beyond just Llama, which was hardcoded in the scripts previously. A number of bugs and formatting issues are also resolved. The scripts that were fixed/updated are:
* `plot_effective_throughput.py`
* `plot_latency_percentile.py`:
* `plot_repl_scale.py`:
* `plot_th_lat.py`:
* `plot_tp_sizes.py`:

Example plots for the scripts:

* `plot_effective_throughput.py`:
![image](https://github.com/microsoft/DeepSpeedExamples/assets/113481193/cbcf00d3-038e-4a89-aa5a-144d19db0cfc)

* `plot_latency_percentile.py`:
![image](https://github.com/microsoft/DeepSpeedExamples/assets/113481193/5641c462-139d-4530-b52e-fefc10242eac)

* `plot_repl_scale.py`:
![image](https://github.com/microsoft/DeepSpeedExamples/assets/113481193/a2b815aa-0cc4-491e-8924-ace7a72286b3)

* `plot_th_lat.py`:
**NOTE:** the resulting data should not be used to draw any conclusions. The GPUs, tp_size, etc are different across the different data points. This is simply demonstrating the plot generation.
![image](https://github.com/microsoft/DeepSpeedExamples/assets/113481193/b9b0c455-c46e-4677-9970-35b342e795c8)

* `plot_tp_sizes.py`:
![image](https://github.com/microsoft/DeepSpeedExamples/assets/113481193/c1d2e9f0-2353-4edd-9b64-62c36a785510)
