### PR TITLE
Remove AML key from args dict when saving results

### DIFF
--- a/benchmarks/inference/mii/src/utils.py
+++ b/benchmarks/inference/mii/src/utils.py
@@ -245,6 +245,9 @@ def save_json_results(
     args: argparse.Namespace, response_details: List[ResponseDetails]
 ) -> None:
     args_dict = vars(args)
+    # Remove AML key from args dictionary
+    if "aml_api_key" in args_dict:
+        args_dict["aml_api_key"] = None
     out_json_path = get_results_path(args)
     os.makedirs(out_json_path.parent, exist_ok=True)
 


### PR DESCRIPTION
This PR removes the `aml_api_key` from the output results files generated by MII inference benchmarks.