### PR TITLE
Update throughput-latency plot script 

### DIFF
--- a/benchmarks/inference/mii/README.md
+++ b/benchmarks/inference/mii/README.md
@@ -66,14 +66,13 @@ The `plot_th_lat.py` throughput-latency plot generation script is generalized fo
 
 The script uses an **_optional_** `plot_config.yaml` that resides within each result directory and allows for overrides in the plot formatting. An example config file may look like this:
 ```yaml
-config:
-  label: "vLLM"
-  color: "purple"
-  marker: "o"
-  linestyle: "--"
-  polyfit_degree: 0
-  x_max : 30
-  y_max : 10
+label: "vLLM"
+color: "purple"
+marker: "o"
+linestyle: "--"
+polyfit_degree: 0
+x_max : 30
+y_max : 10
 ```
 
 Each of the config parameters is optional, allowing for overriding of only the specific plot aspects required, however, all parameters may also be provided.

--- a/benchmarks/inference/mii/README.md
+++ b/benchmarks/inference/mii/README.md
@@ -61,9 +61,35 @@ figures will be saved to `./plots/`
 - `src/plot_repl_scale.py`: This script will plot the throughput and number of replicas for a fixed clients/replica per plot.
 - `src/plot_tp_sizes.py`: This script will plot latency and TFLOPs per GPU across different tensor parallelism sizes.
 
-The following command shows an example of `plot_th_lat.py` execution using the `vllm`, `fastgen`, and `aml` backends.
+## Throughput Latency Plot Generation Script
+The `plot_th_lat.py` throughput-latency plot generation script is generalized for any result output directory, irrespective of where it was run.
+
+The script uses an **_optional_** `plot_config.yaml` that resides within each result directory and allows for overrides in the plot formatting. An example config file may look like this:
+```yaml
+config:
+  label: "vLLM"
+  color: "purple"
+  marker: "o"
+  linestyle: "--"
+  polyfit_degree: 0
+  x_max : 30
+  y_max : 10
+```
+
+Each of the config parameters is optional, allowing for overriding of only the specific plot aspects required, however, all parameters may also be provided.
+
+A few nuances for the `polyfit_degree` and `x/y_max` parameters:
+- `polyfit_degree`: Specifies the polynomial degree for the 'best fit line'. Specifying `0` removes the best fit line and simply connects the scatter plot points.
+- `x/y_max`: Clips the x or y axis data using the specified value as the upper bound.
+
+An example command executing the script may look something like this:
 ```bash
-DeepSpeedExamples/benchmarks/inference/mii$ python3 src/plot_th_lat.py --backend vllm fastgen aml --log_dir results/
+DeepSpeedExamples/benchmarks/inference/mii$ python3 src/plot_th_lat.py --data_dirs ./results/results-* --model_name <plot_model_title>
+```
+
+Or each result directory can be enumerated explicitly:
+```bash
+DeepSpeedExamples/benchmarks/inference/mii$ python3 src/plot_th_lat.py --data_dirs ./results/results-1 ./results/results-2 ./results/results-3 --model_name <plot_model_title>
 ```
 
 ## Running an End-to-End Example

--- a/benchmarks/inference/mii/plot_config.yaml
+++ b/benchmarks/inference/mii/plot_config.yaml
@@ -1,8 +1,7 @@
-config:
-  label: "vLLM"
-  color: "purple"
-  marker: "o"
-  linestyle: "--"
-  polyfit_degree: 0
-  x_max : 30
-  y_max : 10
+label: "vLLM"
+color: "purple"
+marker: "o"
+linestyle: "--"
+polyfit_degree: 0
+x_max : 30
+y_max : 10

--- a/benchmarks/inference/mii/plot_config.yaml
+++ b/benchmarks/inference/mii/plot_config.yaml
@@ -1,0 +1,8 @@
+config:
+  label: "vLLM"
+  color: "purple"
+  marker: "o"
+  linestyle: "--"
+  polyfit_degree: 3
+  scatter: false
+  y_max : 10

--- a/benchmarks/inference/mii/plot_config.yaml
+++ b/benchmarks/inference/mii/plot_config.yaml
@@ -3,6 +3,6 @@ config:
   color: "purple"
   marker: "o"
   linestyle: "--"
-  polyfit_degree: 3
-  scatter: false
+  polyfit_degree: 0
+  x_max : 30
   y_max : 10

--- a/benchmarks/inference/mii/src/plot_th_lat.py
+++ b/benchmarks/inference/mii/src/plot_th_lat.py
@@ -20,7 +20,6 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--data_dirs", type=str, nargs="+", \
                         help="Specify the data directories to generate plots for")
-    parser.add_argument("--log_dir", type=Path, default="./results")
     parser.add_argument("--out_dir", type=Path, default="./plots/throughput_latency")
     parser.add_argument("--model_name", type=str, default="", help="Optional model name override")
     args = parser.parse_args()
@@ -47,7 +46,7 @@ def extract_values(file_pattern):
     return clients, throughputs, latencies, prof_args
 
 
-def output_charts(model, tp_size, bs, replicas, prompt, gen, log_dir, out_dir):
+def output_charts(model, tp_size, bs, replicas, prompt, gen, out_dir):
     out_dir.mkdir(parents=True, exist_ok=True)
 
     result_file_pattern = f"{model}-tp{tp_size}-bs{bs}-replicas{replicas}-prompt{prompt}-gen{gen}-clients*.json"
@@ -55,7 +54,7 @@ def output_charts(model, tp_size, bs, replicas, prompt, gen, log_dir, out_dir):
     plt.figure()
 
     for data_dir in args.data_dirs:
-        file_pattern = f"{log_dir}/{data_dir}/{result_file_pattern}"
+        file_pattern = f"{data_dir}/{result_file_pattern}"
         _, throughputs, latencies, prof_args = extract_values(file_pattern)
 
         kwargs = {}
@@ -70,7 +69,7 @@ def output_charts(model, tp_size, bs, replicas, prompt, gen, log_dir, out_dir):
         polyfit_degree = 3
         plot_fn = plt.scatter
 
-        plot_config = glob.glob(f"{log_dir}/{data_dir}/plot_config.yaml")
+        plot_config = glob.glob(f"{data_dir}/plot_config.yaml")
 
         latencies = sorted(latencies)
         throughputs = sorted(throughputs)
@@ -169,9 +168,6 @@ def output_charts(model, tp_size, bs, replicas, prompt, gen, log_dir, out_dir):
 if __name__ == "__main__":
     args = get_args()
 
-    if not args.log_dir.exists():
-        raise ValueError(f"Log dir {args.log_dir} does not exist")
-
     result_params = get_result_sets(args)
 
     for model, tp_size, bs, replicas, prompt, gen in result_params:
@@ -182,6 +178,5 @@ if __name__ == "__main__":
             replicas=replicas,
             prompt=prompt,
             gen=gen,
-            log_dir=args.log_dir,
             out_dir=args.out_dir,
         )

--- a/benchmarks/inference/mii/src/plot_th_lat.py
+++ b/benchmarks/inference/mii/src/plot_th_lat.py
@@ -7,6 +7,7 @@ import argparse
 import glob
 import os
 import re
+import json
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -17,10 +18,11 @@ from postprocess_results import read_json, get_summary, get_result_sets
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--backend", type=str, choices=["aml", "fastgen", "vllm"], default=["aml", "fastgen", "vllm"], \
-                        nargs="+", help="Specify the backends to generate plots for")
+    parser.add_argument("--data_dirs", type=str, nargs="+", \
+                        help="Specify the data directories to generate plots for")
     parser.add_argument("--log_dir", type=Path, default="./results")
     parser.add_argument("--out_dir", type=Path, default="./plots/throughput_latency")
+    parser.add_argument("--model_name", type=str, default="", help="Optional model name override")
     args = parser.parse_args()
     return args
 
@@ -42,11 +44,7 @@ def extract_values(file_pattern):
         throughputs.append(summary.throughput)
         latencies.append(summary.latency)
 
-        if "aml" in args.backend:
-            extra_args["aml_api_url"] = prof_args["aml_api_url"]
-            extra_args["deployment_name"] = prof_args["deployment_name"]
-
-    return clients, throughputs, latencies, extra_args
+    return clients, throughputs, latencies
 
 
 def output_charts(model, tp_size, bs, replicas, prompt, gen, log_dir, out_dir):
@@ -58,69 +56,117 @@ def output_charts(model, tp_size, bs, replicas, prompt, gen, log_dir, out_dir):
 
     # Plotting the scatter plot
     # vLLM plot formatting
-    if "vllm" in args.backend:
-        vllm_file_pattern = f"{log_dir}/vllm/{result_file_pattern}"
-        _, vllm_throughputs, vllm_latencies, _ = extract_values(vllm_file_pattern)
-        if len(vllm_throughputs) > 0:
-            plt.scatter(
-                vllm_throughputs, vllm_latencies, label=f"vLLM", marker="x", color="orange"
-            )
-            fit_vllm_x_list = np.arange(min(vllm_throughputs), max(vllm_throughputs), 0.01)
-            vllm_vllm_model = np.polyfit(vllm_throughputs, vllm_latencies, 3)
-            vllm_model_fn = np.poly1d(vllm_vllm_model)
-            plt.plot(
-                fit_vllm_x_list,
-                vllm_model_fn(fit_vllm_x_list),
-                color="orange",
-                alpha=0.5,
-                linestyle="--",
+
+    for data_dir in args.data_dirs:
+        file_pattern = f"{log_dir}/{data_dir}/{result_file_pattern}"
+        _, throughputs, latencies = extract_values(file_pattern)
+
+
+        plot_config = glob.glob(f"{log_dir}/{data_dir}/plot_config.json")[0]
+
+        with open(plot_config, "r") as f:
+            plot_config = json.load(f)
+
+        latencies = sorted(latencies)
+        throughputs = sorted(throughputs)
+
+        for i, latency in enumerate(latencies):
+            if latency > 10:
+                latencies = latencies[:i-1]
+                throughputs = throughputs[:i-1]
+                break
+
+        if plot_config["config"]["scatter"]:
+            plot_fn = plt.scatter
+        else:
+            plot_fn = plt.plot
+
+        if len(throughputs) > 0:
+            #plt.scatter(
+            plot_fn(
+                throughputs,
+                latencies,
+                label=plot_config["config"]["label"],
+                marker=plot_config["config"]["marker"],
+                color=plot_config["config"]["color"],
+                linestyle=plot_config["config"]["linestyle"]
             )
 
-    # FastGen plot formatting
-    if "fastgen" in args.backend:
-        mii_file_pattern = f"{log_dir}/fastgen/{result_file_pattern}"
-        _, mii_throughputs, mii_latencies, _ = extract_values(mii_file_pattern)
-        plt.scatter(
-            mii_throughputs,
-            mii_latencies,
-            label=f"DeepSpeed FastGen",
-            marker="o",
-            color="blue",
-        )
-        fit_mii_x_list = np.arange(min(mii_throughputs), max(mii_throughputs), 0.01)
-        mii_fit_model = np.polyfit(mii_throughputs, mii_latencies, 3)
-        mii_model_fn = np.poly1d(mii_fit_model)
-        plt.plot(
-            fit_mii_x_list,
-            mii_model_fn(fit_mii_x_list),
-            color="blue",
-            alpha=0.5,
-            linestyle="--",
-        )
+            if plot_config["config"]["scatter"]:
+                fit_x_list = np.arange(min(throughputs), max(throughputs), 0.01)
+                data_model = np.polyfit(throughputs, latencies, plot_config["config"]["polyfit_degree"])
+                model_fn = np.poly1d(data_model)
+                plt.plot(
+                    fit_x_list,
+                    model_fn(fit_x_list),
+                    color=plot_config["config"]["color"],
+                    alpha=0.5,
+                    linestyle=plot_config["config"]["linestyle"],
+                )
 
-    # AML plot formatting
-    if "aml" in args.backend:
-        aml_file_pattern = f"{log_dir}/aml/{result_file_pattern}"
-        _, aml_throughputs, aml_latencies, aml_args = extract_values(aml_file_pattern)
-        aml_endpoint_name = re.match('^https://(.+?)\.', aml_args["aml_api_url"]).groups()[0]
-        aml_deployment_name = aml_args["deployment_name"]
-        plt.scatter(
-            aml_throughputs,
-            aml_latencies,
-            label=f"AML {aml_endpoint_name.capitalize()}",
-            marker="o",
-            color="purple",
-        )
-        fit_aml_x_list = np.arange(min(aml_throughputs), max(aml_throughputs), 0.01)
-        aml_fit_model = np.polyfit(aml_throughputs, aml_latencies, 3)
-        aml_model_fn = np.poly1d(aml_fit_model)
-        plt.plot(
-            fit_aml_x_list,
-            aml_model_fn(fit_aml_x_list),
-            color="purple",
-            alpha=0.5,
-            linestyle="--",
-        )
+    # if "vllm" in args.data_dirs:
+    #     vllm_file_pattern = f"{log_dir}/vllm/{result_file_pattern}"
+    #     _, vllm_throughputs, vllm_latencies = extract_values(vllm_file_pattern)
+    #     if len(vllm_throughputs) > 0:
+    #         plt.scatter(
+    #             vllm_throughputs, vllm_latencies, label=f"vLLM", marker="x", color="orange"
+    #         )
+    #         fit_vllm_x_list = np.arange(min(vllm_throughputs), max(vllm_throughputs), 0.01)
+    #         vllm_vllm_model = np.polyfit(vllm_throughputs, vllm_latencies, 3)
+    #         vllm_model_fn = np.poly1d(vllm_vllm_model)
+    #         plt.plot(
+    #             fit_vllm_x_list,
+    #             vllm_model_fn(fit_vllm_x_list),
+    #             color="orange",
+    #             alpha=0.5,
+    #             linestyle="--",
+    #         )
+
+    # # FastGen plot formatting
+    # if "fastgen" in args.data_dirs:
+    #     mii_file_pattern = f"{log_dir}/fastgen/{result_file_pattern}"
+    #     _, mii_throughputs, mii_latencies = extract_values(mii_file_pattern)
+    #     plt.scatter(
+    #         mii_throughputs,
+    #         mii_latencies,
+    #         label=f"DeepSpeed FastGen",
+    #         marker="o",
+    #         color="blue",
+    #     )
+    #     fit_mii_x_list = np.arange(min(mii_throughputs), max(mii_throughputs), 0.01)
+    #     mii_fit_model = np.polyfit(mii_throughputs, mii_latencies, 3)
+    #     mii_model_fn = np.poly1d(mii_fit_model)
+    #     plt.plot(
+    #         fit_mii_x_list,
+    #         mii_model_fn(fit_mii_x_list),
+    #         color="blue",
+    #         alpha=0.5,
+    #         linestyle="--",
+    #     )
+
+    # # AML plot formatting
+    # if "aml" in args.data_dirs:
+    #     aml_file_pattern = f"{log_dir}/aml/{result_file_pattern}"
+    #     _, aml_throughputs, aml_latencies = extract_values(aml_file_pattern)
+    #     #aml_endpoint_name = re.match('^https://(.+?)\.', aml_args["aml_api_url"]).groups()[0]
+    #     #aml_deployment_name = aml_args["deployment_name"]
+    #     plt.scatter(
+    #         aml_throughputs,
+    #         aml_latencies,
+    #         label=f"AML {aml_endpoint_name.capitalize()}",
+    #         marker="o",
+    #         color="purple",
+    #     )
+    #     fit_aml_x_list = np.arange(min(aml_throughputs), max(aml_throughputs), 0.01)
+    #     aml_fit_model = np.polyfit(aml_throughputs, aml_latencies, 3)
+    #     aml_model_fn = np.poly1d(aml_fit_model)
+    #     plt.plot(
+    #         fit_aml_x_list,
+    #         aml_model_fn(fit_aml_x_list),
+    #         color="purple",
+    #         alpha=0.5,
+    #         linestyle="--",
+    #     )
 
     # Generic plot formatting
     plt.title(f"Model: {model}, Prompt: {prompt}, Generation: {gen}, TP: {tp_size}")

--- a/benchmarks/inference/mii/src/postprocess_results.py
+++ b/benchmarks/inference/mii/src/postprocess_results.py
@@ -160,9 +160,19 @@ def get_result_sets(args: argparse.Namespace) -> set():
 
     data_sets = defaultdict(set)
 
+    if hasattr(args, "data_dirs"):
+        data_set_dirs = args.data_dirs
+    elif hasattr(args, "backend"):
+        data_set_dirs = args.backend
+
     # Generate data sets
-    for data in args.data_dirs:
-        for f in os.listdir(os.path.join(data)):
+    for data in data_set_dirs:
+        if hasattr(args, "log_dir"):
+            os_path = os.path.join(args.log_dir, data)
+        else:
+            os_path = os.path.join(data)
+
+        for f in os.listdir(os_path):
             match = result_re.match(f)
             if match:
                 data_sets[data].add(match.groups())

--- a/benchmarks/inference/mii/src/postprocess_results.py
+++ b/benchmarks/inference/mii/src/postprocess_results.py
@@ -158,27 +158,27 @@ def get_result_sets(args: argparse.Namespace) -> set():
         r"(.+)-tp(\d+)-bs(\d+)-replicas(\d+)-prompt(\d+)-gen(\d+)-clients.*.json"
     )
 
-    backend_sets = defaultdict(set)
+    data_sets = defaultdict(set)
 
-    # Generate backend sets
-    for backend in args.data_dirs:
-        for f in os.listdir(os.path.join(args.log_dir, backend)):
+    # Generate data sets
+    for data in args.data_dirs:
+        for f in os.listdir(os.path.join(args.log_dir, data)):
             match = result_re.match(f)
             if match:
-                backend_sets[backend].add(match.groups())
+                data_sets[data].add(match.groups())
 
     # Intersection between all sets
-    for backend_set in backend_sets.values():
+    for data_set in data_sets.values():
         if result_params == None:
-            result_params = backend_set
+            result_params = data_set
         else:
-            result_params = result_params.intersection(backend_set)
+            result_params = result_params.intersection(data_set)
 
     # Warning messages about skipped sets
-    for key, backend_set in backend_sets.items():
-        difference = backend_set.difference(result_params)
+    for key, data_set in data_sets.items():
+        difference = data_set.difference(result_params)
         if difference:
-            print(f"WARNING: backend {key} has result combinations that are not present in all backends:")
+            print(f"WARNING: data {key} has result combinations that are not present in all data sets:")
             print(tabulate(difference, headers=["model", "tp_size", "bs", "replicas", "prompt", "gen"]))
             print("")
 

--- a/benchmarks/inference/mii/src/postprocess_results.py
+++ b/benchmarks/inference/mii/src/postprocess_results.py
@@ -161,7 +161,7 @@ def get_result_sets(args: argparse.Namespace) -> set():
     backend_sets = defaultdict(set)
 
     # Generate backend sets
-    for backend in args.backend:
+    for backend in args.data_dirs:
         for f in os.listdir(os.path.join(args.log_dir, backend)):
             match = result_re.match(f)
             if match:

--- a/benchmarks/inference/mii/src/postprocess_results.py
+++ b/benchmarks/inference/mii/src/postprocess_results.py
@@ -162,7 +162,7 @@ def get_result_sets(args: argparse.Namespace) -> set():
 
     # Generate data sets
     for data in args.data_dirs:
-        for f in os.listdir(os.path.join(args.log_dir, data)):
+        for f in os.listdir(os.path.join(data)):
             match = result_re.match(f)
             if match:
                 data_sets[data].add(match.groups())

--- a/benchmarks/inference/mii/src/utils.py
+++ b/benchmarks/inference/mii/src/utils.py
@@ -209,8 +209,7 @@ def get_args_product(
 
 def get_results_path(args: argparse.Namespace) -> Path:
     return Path(
-        args.out_json_dir,
-        f"{args.backend}/",
+        f"{args.out_json_dir}_{args.backend}/",
         "-".join(
             (
                 args.model.replace("/", "_"),


### PR DESCRIPTION
This PR updates the `plot_th_lat.py` throughput-latency plot generation script to remove the concept of a `backend (aml, fastgen, vllm)` and generalize for any result output directory, irrespective of where it was run.

The PR also introduces the concept of an **_optional_** `plot_config.yaml` that resides within each result directory and allows for overrides in the plot formatting. An example config file may look like this:
```yaml
label: "vLLM"
color: "purple"
marker: "o"
linestyle: "--"
polyfit_degree: 0
x_max : 30
y_max : 10
```

Each of the config parameters is optional, allowing for override of only the specific plot aspects required, however all parameters may also be provided.

A few nuances for the `polyfit_degree` and `x/y_max` parameters:
- `polyfit_degree`: Specifies the polynomial degree for the 'best fit line'. Specifying `0` removes the best fit line and simply connects the scatter plot points.
- `x/y_max`: Clips the x or y axis data using the specified value as the upper bound.

An example command executing the script may look something like this:
```bash
python3 src/plot_th_lat.py --data_dirs ./results/results-* --model_name <plot_model_title>
```

Or each result directory can be enumerated explicitly:
```bash
python3 src/plot_th_lat.py --data_dirs ./results/results-1 ./results/results-2 ./results/results-3 --model_name <plot_model_title>
```