### PR TITLE
Update tokens_per_sec calculation to work w/ stream and non-stream cases

### DIFF
--- a/benchmarks/inference/mii/src/postprocess_results.py
+++ b/benchmarks/inference/mii/src/postprocess_results.py
@@ -78,7 +78,9 @@ def get_summary(args, response_details):
 
     tokens_per_sec = mean(
         [
-            (len(get_tokenizer().tokenize(r.prompt)) + len(get_tokenizer().tokenize(r.generated_tokens)))
+            (len(get_tokenizer().tokenize(r.prompt)) +
+            len(get_tokenizer().tokenize(r.generated_tokens)) if type(r.generated_tokens) == str
+            else len(r.generated_tokens))
             / (r.end_time - r.start_time)
             for r in response_details
         ]


### PR DESCRIPTION
This PR updates the `tokens_per_sec` calculation in the MII benchmark to account for both the streaming and non-streaming modes.