### PR TITLE
Add --client-only arg to mii benchmark

### DIFF
--- a/benchmarks/inference/mii/run_benchmark.py
+++ b/benchmarks/inference/mii/run_benchmark.py
@@ -20,7 +20,7 @@ def run_benchmark() -> None:
     args = parse_args(server_args=True, client_args=True)
 
     for server_args in get_args_product(args, which=SERVER_PARAMS):
-        if server_args.backend != "aml":
+        if server_args.backend != "aml" and not server_args.client_only:
             start_server(server_args)
 
         for client_args in get_args_product(server_args, which=CLIENT_PARAMS):
@@ -36,7 +36,7 @@ def run_benchmark() -> None:
             print_summary(client_args, response_details)
             save_json_results(client_args, response_details)
 
-        if server_args.backend != "aml":
+        if server_args.backend != "aml" and not server_args.client_only:
             stop_server(server_args)
 
 

--- a/benchmarks/inference/mii/src/utils.py
+++ b/benchmarks/inference/mii/src/utils.py
@@ -61,6 +61,10 @@ def parse_args(
         choices=["start", "stop", "restart"],
         help="Command for running server.py to manually start/stop/restart a server",
     )
+    server_parser.add_argument(
+        "--client_only", action="store_true", help="Run client only with server started"
+    )
+
 
     # Client args
     client_parser = argparse.ArgumentParser(add_help=False)


### PR DESCRIPTION
This PR add a --client-only flag to mii benchmark, allows the benchmark skip `start_server` and `stop_server` when running with backend such as vllm.   This flag provide the flexibility to start the server to be benchmarked in seperate command line, then benchmark it with this benchmark script.  Experiment different server configuration or debugging will be easier.