### PR TITLE
Enable cpu/xpu support for the benchmarking suite

### DIFF
--- a/benchmarks/communication/README.md
+++ b/benchmarks/communication/README.md
@@ -77,18 +77,14 @@ Finally, users can choose specific communication operations to run in `run_all.p
 deepspeed run_all.py --scan --all-reduce --all-to-all --broadcast
 </pre>
 
-## CPU and other Accelerator Support
-Those benchmarks could also support other devices like Intel CPU and GPU via oneCCL.
+## CPU Support
+Those benchmarks could also support other devices like Intel CPU via oneCCL.
 Users just need to append one more argument "--device cpu" for all python scripts to run on Intel CPU.
 For example, run with a single large message size on Intel CPU:
 <pre>
 deepspeed all_reduce.py --device cpu
 </pre>
 
-To run with a single large message size on Intel GPU:
-<pre>
-deepspeed all_reduce.py --device xpu
-</pre>
 
 # Adding Communication Benchmarks
 

--- a/benchmarks/communication/README.md
+++ b/benchmarks/communication/README.md
@@ -1,6 +1,6 @@
 # The DeepSpeed Communication Benchmarking Suite
 
-The intent of these benchmarks is to measure communication latency/bw of deepspeed and/or pytorch distributed communication operations at the Python layer. These benchmarks are complementary to C-level comms benchmarks like [OSU Micro-Benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks/) and [NCCL Tests](https://github.com/NVIDIA/nccl-tests) in that users can:
+The intent of these benchmarks is to measure communication latency/bw of deepspeed and/or pytorch distributed communication operations at the Python layer. These benchmarks are complementary to C-level comms benchmarks like [OSU Micro-Benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks/) , [NCCL Tests](https://github.com/NVIDIA/nccl-tests) and [oneCCL Benchmark](https://oneapi-src.github.io/oneCCL/benchmark.html) in that users can:
 - Easily debug which layer of the communication software stack hangs or performance degradations originate from.
 - Measure the expected communication performance of either DeepSpeed comms or pure PyTorch distributed
 
@@ -77,6 +77,18 @@ Finally, users can choose specific communication operations to run in `run_all.p
 deepspeed run_all.py --scan --all-reduce --all-to-all --broadcast
 </pre>
 
+## CPU and other Accelerator Support
+Those benchmarks could also support other devices like Intel CPU and GPU via oneCCL.
+Users just need to append one more argument "--device cpu" for all python scripts to run on Intel CPU.
+For example, run with a single large message size on Intel CPU:
+<pre>
+deepspeed all_reduce.py --device cpu
+</pre>
+
+To run with a single large message size on Intel GPU:
+<pre>
+deepspeed all_reduce.py --device xpu
+</pre>
 
 # Adding Communication Benchmarks
 

--- a/benchmarks/communication/all_gather.py
+++ b/benchmarks/communication/all_gather.py
@@ -16,7 +16,10 @@ from deepspeed.comm import TorchBackend
 
 
 # Run all_gather and print metrics
-def timed_all_gather(input, output, start_event, end_event, args):
+def timed_all_gather(input, output, start_event, end_event, args, device):
+    if device == "cpu":
+        print_rank_0(f"No Event support on CPU to measure time for now")
+        return
     if args.dist == 'torch':
         import torch.distributed as dist
 
@@ -53,7 +56,7 @@ def timed_all_gather(input, output, start_event, end_event, args):
     print_rank_0(f"{size:<20} {desc:25s} {duration_str:20s} {tput_str:20s} {busbw_str:20s}")
 
 
-def run_all_gather(local_rank, args):
+def run_all_gather(local_rank, args, device):
     if args.dist == 'torch':
         import torch.distributed as dist
     elif args.dist == 'deepspeed':
@@ -64,8 +67,15 @@ def run_all_gather(local_rank, args):
     global_rank = dist.get_rank()
     world_size = dist.get_world_size()
 
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
+    if device == "xpu":
+        start_event = torch.xpu.Event(enable_timing=True)
+        end_event = torch.xpu.Event(enable_timing=True)
+    elif device == "cpu":
+        start_event = torch.cpu.Event()
+        end_event = torch.cpu.Event()
+    else:
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
 
     if args.scan:
         # Create list of message sizes
@@ -96,7 +106,7 @@ def run_all_gather(local_rank, args):
                 else:
                     raise e
             sync_all()
-            timed_all_gather(input, output, start_event, end_event, args)
+            timed_all_gather(input, output, start_event, end_event, args, device)
     else:
         # all_gather_into_tensor saves memory
         if ((args.dist == 'torch' or args.dist == 'deepspeed') and dist.has_all_gather_into_tensor()):
@@ -130,11 +140,12 @@ def run_all_gather(local_rank, args):
                 raise e
 
         sync_all()
-        timed_all_gather(input, output, start_event, end_event, args)
+        timed_all_gather(input, output, start_event, end_event, args, device)
 
 
 if __name__ == "__main__":
     args = benchmark_parser().parse_args()
     rank = args.local_rank
+    device = args.device
     init_processes(local_rank=rank, args=args)
-    run_all_gather(local_rank=rank, args=args)
+    run_all_gather(local_rank=rank, args=args, device=device)

--- a/benchmarks/communication/all_reduce.py
+++ b/benchmarks/communication/all_reduce.py
@@ -14,7 +14,10 @@ from communication.constants import *
 from deepspeed.accelerator import get_accelerator
 
 
-def timed_all_reduce(input, start_event, end_event, args):
+def timed_all_reduce(input, start_event, end_event, args, device):
+    if device == "cpu":
+        print_rank_0(f"No Event support on CPU to measure time for now")
+        return
     if args.dist == 'torch':
         import torch.distributed as dist
     elif args.dist == 'deepspeed':
@@ -48,7 +51,7 @@ def timed_all_reduce(input, start_event, end_event, args):
     print_rank_0(f"{size:<20} {desc:25s} {duration_str:20s} {tput_str:20s} {busbw_str:20s}")
 
 
-def run_all_reduce(local_rank, args):
+def run_all_reduce(local_rank, args, device):
     if args.dist == 'torch':
         import torch.distributed as dist
     elif args.dist == 'deepspeed':
@@ -60,8 +63,15 @@ def run_all_reduce(local_rank, args):
     world_size = dist.get_world_size()
     global_rank = dist.get_rank()
 
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
+    if device == "xpu":
+        start_event = torch.xpu.Event(enable_timing=True)
+        end_event = torch.xpu.Event(enable_timing=True)
+    elif device == "cpu":
+        start_event = torch.cpu.Event()
+        end_event = torch.cpu.Event()
+    else:
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
 
     if args.scan:
         M_LIST = []
@@ -86,7 +96,7 @@ def run_all_reduce(local_rank, args):
                 else:
                     raise e
             sync_all()
-            timed_all_reduce(input, start_event, end_event, args)
+            timed_all_reduce(input, start_event, end_event, args, device)
     else:
         # Send the biggest message size our GPUs can fit. If you're facing OOM errors, reduce the mem_factor
         # Don't need output tensor, so we double mem_factor
@@ -108,11 +118,12 @@ def run_all_reduce(local_rank, args):
             else:
                 raise e
         sync_all()
-        timed_all_reduce(input, start_event, end_event, args)
+        timed_all_reduce(input, start_event, end_event, args, device)
 
 
 if __name__ == "__main__":
     args = benchmark_parser().parse_args()
     rank = args.local_rank
+    device = args.device
     init_processes(local_rank=rank, args=args)
-    run_all_reduce(local_rank=rank, args=args)
+    run_all_reduce(local_rank=rank, args=args, device=device)

--- a/benchmarks/communication/all_reduce.py
+++ b/benchmarks/communication/all_reduce.py
@@ -14,8 +14,8 @@ from communication.constants import *
 from deepspeed.accelerator import get_accelerator
 
 
-def timed_all_reduce(input, start_event, end_event, args, device):
-    if device == "cpu":
+def timed_all_reduce(input, start_event, end_event, args):
+    if args.device == "cpu":
         print_rank_0(f"No Event support on CPU to measure time for now")
         return
     if args.dist == 'torch':
@@ -51,7 +51,7 @@ def timed_all_reduce(input, start_event, end_event, args, device):
     print_rank_0(f"{size:<20} {desc:25s} {duration_str:20s} {tput_str:20s} {busbw_str:20s}")
 
 
-def run_all_reduce(local_rank, args, device):
+def run_all_reduce(local_rank, args):
     if args.dist == 'torch':
         import torch.distributed as dist
     elif args.dist == 'deepspeed':
@@ -63,10 +63,10 @@ def run_all_reduce(local_rank, args, device):
     world_size = dist.get_world_size()
     global_rank = dist.get_rank()
 
-    if device == "xpu":
+    if args.device == "xpu":
         start_event = torch.xpu.Event(enable_timing=True)
         end_event = torch.xpu.Event(enable_timing=True)
-    elif device == "cpu":
+    elif args.device == "cpu":
         start_event = torch.cpu.Event()
         end_event = torch.cpu.Event()
     else:
@@ -96,7 +96,7 @@ def run_all_reduce(local_rank, args, device):
                 else:
                     raise e
             sync_all()
-            timed_all_reduce(input, start_event, end_event, args, device)
+            timed_all_reduce(input, start_event, end_event, args)
     else:
         # Send the biggest message size our GPUs can fit. If you're facing OOM errors, reduce the mem_factor
         # Don't need output tensor, so we double mem_factor
@@ -118,12 +118,11 @@ def run_all_reduce(local_rank, args, device):
             else:
                 raise e
         sync_all()
-        timed_all_reduce(input, start_event, end_event, args, device)
+        timed_all_reduce(input, start_event, end_event, args)
 
 
 if __name__ == "__main__":
     args = benchmark_parser().parse_args()
     rank = args.local_rank
-    device = args.device
     init_processes(local_rank=rank, args=args)
-    run_all_reduce(local_rank=rank, args=args, device=device)
+    run_all_reduce(local_rank=rank, args=args)

--- a/benchmarks/communication/broadcast.py
+++ b/benchmarks/communication/broadcast.py
@@ -14,7 +14,10 @@ from communication.constants import *
 from deepspeed.accelerator import get_accelerator
 
 
-def timed_broadcast(input, start_event, end_event, args):
+def timed_broadcast(input, start_event, end_event, args, device):
+    if device == "cpu":
+        print_rank_0(f"No Event support on CPU to measure time for now")
+        return
     if args.dist == 'torch':
         import torch.distributed as dist
     elif args.dist == 'deepspeed':
@@ -48,7 +51,7 @@ def timed_broadcast(input, start_event, end_event, args):
     print_rank_0(f"{size:<20} {desc:25s} {duration_str:20s} {tput_str:20s} {busbw_str:20s}")
 
 
-def run_broadcast(local_rank, args):
+def run_broadcast(local_rank, args, device):
     if args.dist == 'torch':
         import torch.distributed as dist
     elif args.dist == 'deepspeed':
@@ -60,8 +63,15 @@ def run_broadcast(local_rank, args):
     world_size = dist.get_world_size()
     global_rank = dist.get_rank()
 
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
+    if device == "xpu":
+        start_event = torch.xpu.Event(enable_timing=True)
+        end_event = torch.xpu.Event(enable_timing=True)
+    elif device == "cpu":
+        start_event = torch.cpu.Event()
+        end_event = torch.cpu.Event()
+    else:
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
 
     if args.scan:
         M_LIST = []
@@ -86,7 +96,7 @@ def run_broadcast(local_rank, args):
                 else:
                     raise e
             sync_all()
-            timed_broadcast(input, start_event, end_event, args)
+            timed_broadcast(input, start_event, end_event, args, device)
     else:
         # Send the biggest message size our GPUs can fit. If you're facing OOM errors, reduce the mem_factor
         # Don't need output tensor, so we double mem_factor
@@ -106,11 +116,12 @@ def run_broadcast(local_rank, args):
                 sync_all()
                 return
         sync_all()
-        timed_broadcast(input, start_event, end_event, args)
+        timed_broadcast(input, start_event, end_event, args, device)
 
 
 if __name__ == "__main__":
     args = benchmark_parser().parse_args()
     rank = args.local_rank
+    device = args.device
     init_processes(local_rank=rank, args=args)
-    run_broadcast(local_rank=rank, args=args)
+    run_broadcast(local_rank=rank, args=args, device=device)

--- a/benchmarks/communication/constants.py
+++ b/benchmarks/communication/constants.py
@@ -12,4 +12,5 @@ DEFAULT_BACKEND = get_accelerator().communication_backend_name()
 DEFAULT_UNIT = 'Gbps'
 DEFAULT_DIST = 'deepspeed'
 DEFAULT_MAXSIZE = 24
+DEFAULT_DEVICE = 'cuda'
 TORCH_DISTRIBUTED_DEFAULT_PORT = 29500

--- a/benchmarks/communication/pt2pt.py
+++ b/benchmarks/communication/pt2pt.py
@@ -14,8 +14,8 @@ from communication.constants import *
 from deepspeed.accelerator import get_accelerator
 
 
-def timed_pt2pt(input, start_event, end_event, args, device):
-    if device == "cpu":
+def timed_pt2pt(input, start_event, end_event, args):
+    if args.device == "cpu":
         print_rank_0(f"No Event support on CPU to measure time for now")
         return
     if args.dist == 'torch':
@@ -70,7 +70,7 @@ def timed_pt2pt(input, start_event, end_event, args, device):
     print_rank_0(f"{size:<20} {desc:25s} {duration_str:20s} {tput_str:20s} {busbw_str:20s}")
 
 
-def run_pt2pt(local_rank, args, device):
+def run_pt2pt(local_rank, args):
     if args.dist == 'torch':
         import torch.distributed as dist
     elif args.dist == 'deepspeed':
@@ -81,10 +81,10 @@ def run_pt2pt(local_rank, args, device):
     global_rank = dist.get_rank()
     world_size = dist.get_world_size()
 
-    if device == "xpu":
+    if args.device == "xpu":
         start_event = torch.xpu.Event(enable_timing=True)
         end_event = torch.xpu.Event(enable_timing=True)
-    elif device == "cpu":
+    elif args.device == "cpu":
         start_event = torch.cpu.Event()
         end_event = torch.cpu.Event()
     else:
@@ -115,7 +115,7 @@ def run_pt2pt(local_rank, args, device):
                 else:
                     raise e
             sync_all()
-            timed_pt2pt(input, start_event, end_event, args, device)
+            timed_pt2pt(input, start_event, end_event, args)
     else:
         # Send the biggest message size our GPUs can fit. If you're facing OOM errors, reduce the mem_factor
         # Don't need output tensor, so double mem_factor
@@ -135,12 +135,11 @@ def run_pt2pt(local_rank, args, device):
                 sync_all()
                 return
         sync_all()
-        timed_pt2pt(input, start_event, end_event, args, device)
+        timed_pt2pt(input, start_event, end_event, args)
 
 
 if __name__ == "__main__":
     args = benchmark_parser().parse_args()
     rank = args.local_rank
-    device = args.device
     init_processes(local_rank=rank, args=args)
-    run_pt2pt(local_rank=rank, args=args, device=device)
+    run_pt2pt(local_rank=rank, args=args)

--- a/benchmarks/communication/run_all.py
+++ b/benchmarks/communication/run_all.py
@@ -18,7 +18,7 @@ from communication.constants import *
 
 
 # For importing
-def main(args, rank):
+def main(args, rank, device):
 
     init_processes(local_rank=rank, args=args)
 
@@ -39,19 +39,20 @@ def main(args, rank):
 
     for comm_op in ops_to_run:
         if comm_op == 'all_reduce':
-            run_all_reduce(local_rank=rank, args=args)
+            run_all_reduce(local_rank=rank, args=args, device=device)
         if comm_op == 'all_gather':
-            run_all_gather(local_rank=rank, args=args)
+            run_all_gather(local_rank=rank, args=args, device=device)
         if comm_op == 'all_to_all':
-            run_all_to_all(local_rank=rank, args=args)
+            run_all_to_all(local_rank=rank, args=args, device=device)
         if comm_op == 'pt2pt':
-            run_pt2pt(local_rank=rank, args=args)
+            run_pt2pt(local_rank=rank, args=args, device=device)
         if comm_op == 'broadcast':
-            run_broadcast(local_rank=rank, args=args)
+            run_broadcast(local_rank=rank, args=args, device=device)
 
 
 # For directly calling benchmark
 if __name__ == "__main__":
     args = benchmark_parser().parse_args()
     rank = args.local_rank
-    main(args, rank)
+    device = args.device
+    main(args, rank, device=device)

--- a/benchmarks/communication/run_all.py
+++ b/benchmarks/communication/run_all.py
@@ -18,7 +18,7 @@ from communication.constants import *
 
 
 # For importing
-def main(args, rank, device):
+def main(args, rank):
 
     init_processes(local_rank=rank, args=args)
 
@@ -39,20 +39,19 @@ def main(args, rank, device):
 
     for comm_op in ops_to_run:
         if comm_op == 'all_reduce':
-            run_all_reduce(local_rank=rank, args=args, device=device)
+            run_all_reduce(local_rank=rank, args=args)
         if comm_op == 'all_gather':
-            run_all_gather(local_rank=rank, args=args, device=device)
+            run_all_gather(local_rank=rank, args=args)
         if comm_op == 'all_to_all':
-            run_all_to_all(local_rank=rank, args=args, device=device)
+            run_all_to_all(local_rank=rank, args=args)
         if comm_op == 'pt2pt':
-            run_pt2pt(local_rank=rank, args=args, device=device)
+            run_pt2pt(local_rank=rank, args=args)
         if comm_op == 'broadcast':
-            run_broadcast(local_rank=rank, args=args, device=device)
+            run_broadcast(local_rank=rank, args=args)
 
 
 # For directly calling benchmark
 if __name__ == "__main__":
     args = benchmark_parser().parse_args()
     rank = args.local_rank
-    device = args.device
-    main(args, rank, device=device)
+    main(args, rank)

--- a/benchmarks/communication/utils.py
+++ b/benchmarks/communication/utils.py
@@ -110,7 +110,7 @@ def get_bw(comm_op, size, duration, args):
     busbw = 0
 
     if duration == 0:
-        print_rank_0("Error. duration is 0.")
+        print_rank_0("Error. Duration is 0.")
         return tput, busbw
 
     if comm_op == "all_to_all":

--- a/benchmarks/communication/utils.py
+++ b/benchmarks/communication/utils.py
@@ -108,6 +108,11 @@ def get_bw(comm_op, size, duration, args):
     n = dist.get_world_size()
     tput = 0
     busbw = 0
+
+    if duration == 0:
+        print_rank_0("Error. duration is 0.")
+        return tput, busbw
+
     if comm_op == "all_to_all":
         tput = (size / duration)
         busbw = (size / duration) * ((n - 1) / n)
@@ -235,4 +240,5 @@ def benchmark_parser():
                         default=.3,
                         help='Proportion of max available GPU memory to use for single-size evals')
     parser.add_argument("--debug", action="store_true", help='Enables all_to_all debug prints')
+    parser.add_argument("--device", type=str, default=DEFAULT_DEVICE, help='target device')
     return parser


### PR DESCRIPTION
Enable Intel CPU and Intel XPU support for Benchmark Suite.
Many customers use deepspeed on CPU and XPU for LLM models, and this benchmark suite helps them to debugging communication issues on their environment.

an screenshot for two nodes run of all_reduce.py on CPU
![image](https://github.com/microsoft/DeepSpeedExamples/assets/21761437/6e6caa4a-d866-403a-ad4a-a0108e7d7097)

an screenshot for two cards run of run_all.py on XPU
![image](https://github.com/microsoft/DeepSpeedExamples/assets/21761437/638836d6-37fc-466d-9c14-5562c7d1acea)
