### PR TITLE
[cifar ds training]: Set cuda device during initialization of distributed backend.

### DIFF
--- a/training/cifar/cifar10_deepspeed.py
+++ b/training/cifar/cifar10_deepspeed.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 import deepspeed
 import torch
@@ -279,6 +280,9 @@ def test(model_engine, testset, local_device, target_dtype, test_batch_size=4):
 def main(args):
     # Initialize DeepSpeed distributed backend.
     deepspeed.init_distributed()
+    _local_rank = int(os.environ.get("LOCAL_RANK"))
+    torch_device = torch.device(f"cuda:{_local_rank}")
+    torch.cuda.set_device(torch_device)
 
     ########################################################################
     # Step1. Data Preparation.

--- a/training/cifar/cifar10_deepspeed.py
+++ b/training/cifar/cifar10_deepspeed.py
@@ -281,8 +281,7 @@ def main(args):
     # Initialize DeepSpeed distributed backend.
     deepspeed.init_distributed()
     _local_rank = int(os.environ.get("LOCAL_RANK"))
-    torch_device = torch.device(f"cuda:{_local_rank}")
-    torch.cuda.set_device(torch_device)
+    get_accelerator().set_device(_local_rank)
 
     ########################################################################
     # Step1. Data Preparation.


### PR DESCRIPTION
The commit is needed to avoid GPU 0 being set as the compute stream via torch.cuda.current_stream() during initialization across all GPUs.
The perf RunningAvgSamplesPerSec metrics improves on a multi gpu node, tested on AMD GPU with ROCm stack.
As number of GPUs increases; without this commit, GPU 0 takes in more load compared to other GPUs.